### PR TITLE
Remove go tip from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 go:
   - 1.7.x
   - 1.8.x
-  - tip
 
 go_import_path: github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
Seems go tip fails randomly, removing it from travis.

Closes #83 .