### PR TITLE
Add GinkgoRecover() to the goroutines to prevent panics

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -310,6 +310,7 @@ func stopContainer(c internalapi.RuntimeService, containerID string, timeout int
 	stopped := make(chan bool, 1)
 
 	go func() {
+		defer GinkgoRecover()
 		err := c.StopContainer(containerID, timeout)
 		framework.ExpectNoError(err, "failed to stop container: %v", err)
 		stopped <- true

--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -192,6 +192,7 @@ func checkAttach(c internalapi.RuntimeService, attachServerURL string) {
 	var out string
 
 	go func() {
+		defer GinkgoRecover()
 		writer.Write([]byte("echo hello\n"))
 		Eventually(func() string {
 			out = localOut.String()
@@ -245,6 +246,7 @@ func checkPortForward(c internalapi.RuntimeService, portForwardSeverURL string) 
 	framework.ExpectNoError(err, "failed to create port forward for %q", portForwardSeverURL)
 
 	go func() {
+		defer GinkgoRecover()
 		By("start port forward")
 		err = pf.ForwardPorts()
 		framework.ExpectNoError(err, "failed to start port forward for %q", portForwardSeverURL)


### PR DESCRIPTION
Assertion in goroutines may cause panics that cannot be rescued by
ginkgo. Add GinkgoRecover() to prevent tests panicing.