### PR TITLE
Support environment variables in critest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ CLI for kubelet CRI
 
 #### Commands
 
-- `version`: Get version information of runtime
+- `info`: Get version information of runtime
 
 - `sandbox`, `sb`: Manage lifecycle of podsandbox
 

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -343,11 +343,11 @@ func ContainerStatus(client pb.RuntimeServiceClient, ID string) error {
 		stm := time.Unix(0, r.Status.StartedAt)
 		fmt.Printf("Started: %v\n", stm)
 	}
-	if r.Status.FinishedAt != 0 {
-		ftm := time.Unix(0, r.Status.FinishedAt)
-		fmt.Printf("Finished: %v\n", ftm)
-	}
 	if r.Status.State == pb.ContainerState_CONTAINER_EXITED {
+		if r.Status.FinishedAt > 0 {
+			ftm := time.Unix(0, r.Status.FinishedAt)
+			fmt.Printf("Finished: %v\n", ftm)
+		}
 		fmt.Printf("Exit Code: %v\n", r.Status.ExitCode)
 	}
 

--- a/cmd/critest/main.go
+++ b/cmd/critest/main.go
@@ -53,12 +53,14 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:        "runtime-endpoint, r",
+			EnvVar:      "CRI_RUNTIME_ENDPOINT",
 			Value:       "/var/run/dockershim.sock",
 			Usage:       "CRI runtime service address which is tested.",
 			Destination: &runtimeServiceAddress,
 		},
 		cli.StringFlag{
 			Name:        "image-endpoint, i",
+			EnvVar:      "CRI_IMAGE_ENDPOINT",
 			Usage:       "CRI image service address which is tested. Same with runtime-address if not specified.",
 			Destination: &imageServiceAddress,
 		},


### PR DESCRIPTION
This PR adds `CRI_RUNTIME_ENDPOINT` and `CRI_IMAGE_ENDPOINT` for critest. It also

* Fixes subcommand list in readme
* Only show finished time when container is exited