### PR TITLE
Use busybox:1.26 instead of gcr.io/google_containers/busybox:1.24.

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -50,7 +50,7 @@ const (
 	DefaultAttempt uint32 = 2
 
 	// DefaultContainerImage is the default image for container using
-	DefaultContainerImage string = "gcr.io/google_containers/busybox:1.24"
+	DefaultContainerImage string = "busybox:1.26"
 
 	// DefaultStopContainerTimeout is the default timeout for stopping container
 	DefaultStopContainerTimeout int64 = 60


### PR DESCRIPTION
`gcr.io/google_containers/busybox:1.24` is still using [schema 1 manifest](https://docs.docker.com/registry/spec/manifest-v2-1/), which is not supported by containerd for now.

Use `busybox:1.26` instead.
 
Signed-off-by: Lantao Liu <lantaol@google.com>

@feiskyer Is this OK to you?