### PR TITLE
add skip flag for critest

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ go get github.com/kubernetes-incubator/cri-tools/cmd/crictl
 
 - `--focus`,`-f`:CRI test will only run the test that match the focus regular expression.
 
+- `--skip`,`-s`:CRI test will not run the test that match the focus regular expression.
+
 ### crictl
 
 CLI for kubelet CRI

--- a/cmd/critest/main.go
+++ b/cmd/critest/main.go
@@ -61,6 +61,10 @@ func main() {
 			Name:  "focus, f",
 			Usage: "critest will only run the test that match the focus regular expression.",
 		},
+		cli.StringFlag{
+			Name:  "skip, s",
+			Usage: "critest will not run the test that match the skip regular expression.",
+		},
 	}
 
 	sort.Sort(cli.FlagsByName(app.Flags))

--- a/cmd/critest/util.go
+++ b/cmd/critest/util.go
@@ -123,6 +123,9 @@ func runTestSuite(context *cli.Context, benchmark bool) error {
 	if context.GlobalString("f") != "" {
 		ginkgoFlags = ginkgoFlags + " -focus=\"" + context.GlobalString("f") + "\""
 	}
+	if context.GlobalString("s") != "" {
+		ginkgoFlags = ginkgoFlags + " -skip=\"" + context.GlobalString("s") + "\""
+	}
 
 	if benchmark {
 		args = []string{ginkgoFlags, filepath.Join(outputDir, "benchmark.test"), "--", "--runtime-service-address=" + context.GlobalString("r"), "--image-service-address=" + imageServiceAddress, "--number=" + context.String("n")}


### PR DESCRIPTION
@feiskyer Runtime developer can use `skip` to ignore sections those is not ready.

ref: https://github.com/kubernetes/frakti/pull/146
Signed-off-by: heartlock <21521209@zju.edu.cn>