### PR TITLE
cmd: crictl: add quiet option

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -174,7 +174,7 @@ var listContainersCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "verbose, v",
-			Usage: "show verbos information for containers",
+			Usage: "show verbose information for containers",
 		},
 		cli.StringFlag{
 			Name:  "id",
@@ -195,6 +195,10 @@ var listContainersCommand = cli.Command{
 			Name:  "label",
 			Usage: "filter by key=value label",
 		},
+		cli.BoolFlag{
+			Name:  "quiet",
+			Usage: "list only container IDs",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := getRuntimeClient(context); err != nil {
@@ -207,6 +211,7 @@ var listContainersCommand = cli.Command{
 			state:   context.String("state"),
 			verbose: context.Bool("verbose"),
 			labels:  make(map[string]string),
+			quiet:   context.Bool("quiet"),
 		}
 
 		for _, l := range context.StringSlice("label") {
@@ -397,6 +402,10 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 	}
 	printHeader := true
 	for _, c := range r.GetContainers() {
+		if opts.quiet {
+			fmt.Printf("%s\n", c.Id)
+			continue
+		}
 		ctm := time.Unix(0, c.CreatedAt)
 		if !opts.verbose {
 			if printHeader {

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -69,6 +69,10 @@ var listImageCommand = cli.Command{
 			Name:  "verbose, v",
 			Usage: "show verbose info for images",
 		},
+		cli.BoolFlag{
+			Name:  "quiet",
+			Usage: "list only image IDs",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := getImageClient(context); err != nil {
@@ -83,6 +87,10 @@ var listImageCommand = cli.Command{
 		verbose := context.Bool("verbose")
 		printHeader := true
 		for _, image := range r.Images {
+			if context.Bool("quiet") {
+				fmt.Printf("%s\n", image.Id)
+				continue
+			}
 			if !verbose {
 				if printHeader {
 					printHeader = false

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -158,6 +158,10 @@ var listPodSandboxCommand = cli.Command{
 			Name:  "verbose, v",
 			Usage: "show verbose info for sandboxes",
 		},
+		cli.BoolFlag{
+			Name:  "quiet",
+			Usage: "list only sandbox IDs",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := getRuntimeClient(context); err != nil {
@@ -169,6 +173,7 @@ var listPodSandboxCommand = cli.Command{
 			state:   context.String("state"),
 			verbose: context.Bool("verbose"),
 			labels:  make(map[string]string),
+			quiet:   context.Bool("quiet"),
 		}
 
 		for _, l := range context.StringSlice("label") {
@@ -318,6 +323,10 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 	}
 	printHeader := true
 	for _, pod := range r.Items {
+		if opts.quiet {
+			fmt.Printf("%s\n", pod.Id)
+			continue
+		}
 		if !opts.verbose {
 			if printHeader {
 				printHeader = false

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -42,6 +42,8 @@ type listOptions struct {
 	verbose bool
 	// labels are selectors for the sandbox
 	labels map[string]string
+	// quiet is for listing just container/sandbox/image IDs
+	quiet bool
 }
 
 type execOptions struct {


### PR DESCRIPTION
We're porting all of the CRI-O integration tests to cri-tools. This patch ensures a smooth transaction and add a useful feature to `ls` commands (think about batch removal).

This is also part of https://github.com/kubernetes-incubator/cri-o/issues/504

Signed-off-by: Antonio Murdaca <runcom@redhat.com>