### PR TITLE
Fix container log test.

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -419,7 +419,7 @@ func parseLogLine(podConfig *runtimeapi.PodSandboxConfig, logPath string) []logM
 		line := scanner.Text()
 
 		// to determine whether the log is Docker format or CRI format.
-		if strings.Contains(line, "{") {
+		if strings.HasPrefix(line, "{") {
 			parseDockerJSONLog([]byte(line), &msg)
 		} else {
 			parseCRILog(line, &msg)
@@ -431,7 +431,7 @@ func parseLogLine(podConfig *runtimeapi.PodSandboxConfig, logPath string) []logM
 	if err := scanner.Err(); err != nil {
 		framework.ExpectNoError(err, "failed to read log by row: %v", err)
 	}
-	framework.Logf("Parse json log succeed")
+	framework.Logf("Parse container log succeed")
 
 	return msgLog
 }


### PR DESCRIPTION
In current logic, if a log has `{` in its content, it will be treated as json log, which is wrong.

This PR fixes that.

Signed-off-by: Lantao Liu <lantaol@google.com>

@feiskyer @Helen-Xie 