### PR TITLE
Remove unsupported go1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.7.x
   - 1.8.x
 
 go_import_path: github.com/kubernetes-incubator/cri-tools


### PR DESCRIPTION
Kubernetes only support go1.8 now, or else it won't compile. This PR removes go1.7 in travis.

Fix #104.