### PR TITLE
Fix image validation test.

### DIFF
--- a/pkg/validate/image.go
+++ b/pkg/validate/image.go
@@ -105,7 +105,6 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 	It("listImage should get exactly 3 repoTags in the result image [Conformance]", func() {
 		// different tags refer to the same image
 		testImageList := []string{
-			"busybox:1.26.2-uclibc",
 			"busybox:1-uclibc",
 			"busybox:1",
 		}
@@ -119,9 +118,6 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 		count := 0
 		for _, imageName := range images {
 			for _, imagesTag := range imageName.RepoTags {
-				if strings.HasSuffix(imagesTag, "busybox:1.26.2-uclibc") {
-					count = count + 1
-				}
 				if strings.HasSuffix(imagesTag, "busybox:1-uclibc") {
 					count = count + 1
 				}
@@ -129,11 +125,11 @@ var _ = framework.KubeDescribe("Image Manager", func() {
 					count = count + 1
 				}
 			}
-			if count < 3 {
+			if count < 2 {
 				count = 0
 			}
 		}
-		Expect(count).To(Equal(3), "Should have three repoTags in single image in list")
+		Expect(count).To(Equal(2), "Should have three repoTags in single image in list")
 	})
 })
 


### PR DESCRIPTION
`busybox:1.26.2-uclibc` is not the same with `busybox:1-uclibc` and `busybox:1` now.

See https://hub.docker.com/_/busybox/

Signed-off-by: Lantao Liu <lantaol@google.com>