### PR TITLE
Simplify crictl CLI

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -41,6 +41,11 @@
 			"Rev": "b9f10c951893f9a00865890a5232e85d770c1087"
 		},
 		{
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.3.1-12-g0dadbb0",
+			"Rev": "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
+		},
+		{
 			"ImportPath": "github.com/docker/spdystream",
 			"Rev": "449fdfce4d962303d702fec724ef0ad181c92528"
 		},

--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -33,16 +33,16 @@ import (
 
 var runtimeAttachCommand = cli.Command{
 	Name:      "attach",
-	Usage:     "attach a running container",
-	ArgsUsage: "containerID",
+	Usage:     "Attach to a running container",
+	ArgsUsage: "CONTAINER",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "tty,t",
-			Usage: "Stdin is a TTY",
+			Usage: "Allocate a pseudo-TTY",
 		},
 		cli.BoolFlag{
 			Name:  "stdin,i",
-			Usage: "Pass stdin to the container",
+			Usage: "Keep STDIN open",
 		},
 	},
 	Action: func(context *cli.Context) error {

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -19,29 +19,17 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	units "github.com/docker/go-units"
 	"github.com/urfave/cli"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
-
-var runtimeContainerCommand = cli.Command{
-	Name:    "container",
-	Usage:   "manage containers",
-	Aliases: []string{"ctr"},
-	Subcommands: []cli.Command{
-		createContainerCommand,
-		startContainerCommand,
-		stopContainerCommand,
-		removeContainerCommand,
-		containerStatusCommand,
-		listContainersCommand,
-	},
-	After: closeConnection,
-}
 
 type createOptions struct {
 	// configPath is path to the config for container
@@ -54,8 +42,8 @@ type createOptions struct {
 
 var createContainerCommand = cli.Command{
 	Name:      "create",
-	Usage:     "create a container",
-	ArgsUsage: "sandboxID container-config.json sandbox-config.json",
+	Usage:     "Create a new container",
+	ArgsUsage: "SANDBOX container-config.json sandbox-config.json",
 	Flags:     []cli.Flag{},
 	Action: func(context *cli.Context) error {
 		if len(context.Args()) != 3 {
@@ -82,8 +70,8 @@ var createContainerCommand = cli.Command{
 
 var startContainerCommand = cli.Command{
 	Name:      "start",
-	Usage:     "start a container",
-	ArgsUsage: "containerID",
+	Usage:     "Start a stopped container",
+	ArgsUsage: "CONTAINER",
 	Action: func(context *cli.Context) error {
 		containerID := context.Args().First()
 		if containerID == "" {
@@ -104,8 +92,8 @@ var startContainerCommand = cli.Command{
 
 var stopContainerCommand = cli.Command{
 	Name:      "stop",
-	Usage:     "stop the container",
-	ArgsUsage: "containerID",
+	Usage:     "Stop a running container",
+	ArgsUsage: "CONTAINER",
 	Action: func(context *cli.Context) error {
 		containerID := context.Args().First()
 		if containerID == "" {
@@ -126,8 +114,8 @@ var stopContainerCommand = cli.Command{
 
 var removeContainerCommand = cli.Command{
 	Name:      "rm",
-	Usage:     "remove the container",
-	ArgsUsage: "containerID",
+	Usage:     "Remove a container",
+	ArgsUsage: "CONTAINER",
 	Action: func(context *cli.Context) error {
 		containerID := context.Args().First()
 		if containerID == "" {
@@ -147,9 +135,15 @@ var removeContainerCommand = cli.Command{
 }
 
 var containerStatusCommand = cli.Command{
-	Name:      "status",
-	Usage:     "get status of the container",
-	ArgsUsage: "containerID",
+	Name:      "inspect",
+	Usage:     "Display the status of a container",
+	ArgsUsage: "CONTAINER",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "Output format, One of: json|yaml|table",
+		},
+	},
 	Action: func(context *cli.Context) error {
 		containerID := context.Args().First()
 		if containerID == "" {
@@ -160,7 +154,7 @@ var containerStatusCommand = cli.Command{
 			return err
 		}
 
-		err := ContainerStatus(runtimeClient, containerID)
+		err := ContainerStatus(runtimeClient, containerID, context.String("output"))
 		if err != nil {
 			return fmt.Errorf("Getting the status of the container failed: %v", err)
 		}
@@ -169,35 +163,39 @@ var containerStatusCommand = cli.Command{
 }
 
 var listContainersCommand = cli.Command{
-	Name:  "ls",
-	Usage: "list containers",
+	Name:  "ps",
+	Usage: "List containers",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "verbose, v",
-			Usage: "show verbose information for containers",
+			Usage: "Show verbose information for containers",
 		},
 		cli.StringFlag{
 			Name:  "id",
 			Value: "",
-			Usage: "filter by container id",
+			Usage: "Filter by container id",
 		},
 		cli.StringFlag{
 			Name:  "sandbox",
 			Value: "",
-			Usage: "filter by sandbox id",
+			Usage: "Filter by sandbox id",
 		},
 		cli.StringFlag{
 			Name:  "state",
 			Value: "",
-			Usage: "filter by container state",
+			Usage: "Filter by container state",
 		},
 		cli.StringSliceFlag{
 			Name:  "label",
-			Usage: "filter by key=value label",
+			Usage: "Filter by key=value label",
 		},
 		cli.BoolFlag{
 			Name:  "quiet",
-			Usage: "list only container IDs",
+			Usage: "Only display container IDs",
+		},
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "Output format, One of: json|yaml|table",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -212,6 +210,7 @@ var listContainersCommand = cli.Command{
 			verbose: context.Bool("verbose"),
 			labels:  make(map[string]string),
 			quiet:   context.Bool("quiet"),
+			output:  context.String("output"),
 		}
 
 		for _, l := range context.StringSlice("label") {
@@ -319,7 +318,7 @@ func RemoveContainer(client pb.RuntimeServiceClient, ID string) error {
 
 // ContainerStatus sends a ContainerStatusRequest to the server, and parses
 // the returned ContainerStatusResponse.
-func ContainerStatus(client pb.RuntimeServiceClient, ID string) error {
+func ContainerStatus(client pb.RuntimeServiceClient, ID, output string) error {
 	if ID == "" {
 		return fmt.Errorf("ID cannot be empty")
 	}
@@ -332,6 +331,16 @@ func ContainerStatus(client pb.RuntimeServiceClient, ID string) error {
 	if err != nil {
 		return err
 	}
+
+	switch output {
+	case "json":
+		return outputJson(r.Status)
+
+	case "yaml":
+		return outputYaml(r.Status)
+	}
+
+	// output in table format by default.
 	fmt.Printf("ID: %s\n", r.Status.Id)
 	if r.Status.Metadata != nil {
 		if r.Status.Metadata.Name != "" {
@@ -343,15 +352,15 @@ func ContainerStatus(client pb.RuntimeServiceClient, ID string) error {
 	}
 	fmt.Printf("State: %s\n", r.Status.State)
 	ctm := time.Unix(0, r.Status.CreatedAt)
-	fmt.Printf("Created: %v\n", ctm)
+	fmt.Printf("Created: %v\n", units.HumanDuration(time.Now().UTC().Sub(ctm))+" ago")
 	if r.Status.State != pb.ContainerState_CONTAINER_CREATED {
 		stm := time.Unix(0, r.Status.StartedAt)
-		fmt.Printf("Started: %v\n", stm)
+		fmt.Printf("Started: %v\n", units.HumanDuration(time.Now().UTC().Sub(stm))+" ago")
 	}
 	if r.Status.State == pb.ContainerState_CONTAINER_EXITED {
 		if r.Status.FinishedAt > 0 {
 			ftm := time.Unix(0, r.Status.FinishedAt)
-			fmt.Printf("Finished: %v\n", ftm)
+			fmt.Printf("Finished: %v\n", units.HumanDuration(time.Now().UTC().Sub(ftm))+" ago")
 		}
 		fmt.Printf("Exit Code: %v\n", r.Status.ExitCode)
 	}
@@ -400,21 +409,35 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 	if err != nil {
 		return err
 	}
+
+	switch opts.output {
+	case "json":
+		return outputJson(r.Containers)
+
+	case "yaml":
+		return outputYaml(r.Containers)
+	}
+
+	// output in table format by default.
 	printHeader := true
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 	for _, c := range r.GetContainers() {
 		if opts.quiet {
 			fmt.Printf("%s\n", c.Id)
 			continue
 		}
-		ctm := time.Unix(0, c.CreatedAt)
+
+		createdAt := time.Unix(0, c.CreatedAt)
+		ctm := units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 		if !opts.verbose {
 			if printHeader {
 				printHeader = false
-				fmt.Println("CONTAINER ID\tCREATED\tSTATE\tNAME")
+				fmt.Fprintln(w, "CONTAINER ID\tCREATED\tSTATE\tNAME")
 			}
-			fmt.Printf("%s\t%s\t%s\t%s\n", c.Id, ctm, c.State, c.GetMetadata().GetName())
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Id, ctm, c.State, c.GetMetadata().GetName())
 			continue
 		}
+
 		fmt.Printf("ID: %s\n", c.Id)
 		fmt.Printf("SandboxID: %s\n", c.PodSandboxId)
 		if c.Metadata != nil {
@@ -442,5 +465,7 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 		}
 		fmt.Println()
 	}
+
+	w.Flush()
 	return nil
 }

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -334,10 +334,10 @@ func ContainerStatus(client pb.RuntimeServiceClient, ID, output string) error {
 
 	switch output {
 	case "json":
-		return outputJson(r.Status)
+		return outputJSON(r.Status)
 
 	case "yaml":
-		return outputYaml(r.Status)
+		return outputYAML(r.Status)
 	}
 
 	// output in table format by default.
@@ -412,10 +412,10 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 
 	switch opts.output {
 	case "json":
-		return outputJson(r.Containers)
+		return outputJSON(r.Containers)
 
 	case "yaml":
-		return outputYaml(r.Containers)
+		return outputYAML(r.Containers)
 	}
 
 	// output in table format by default.

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -38,25 +38,25 @@ const (
 
 var runtimeExecCommand = cli.Command{
 	Name:      "exec",
-	Usage:     "exec a command in a container",
-	ArgsUsage: "containerID COMMAND [ARG...]",
+	Usage:     "Run a command in a running container",
+	ArgsUsage: "CONTAINER COMMAND [ARG...]",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
-			Name:  "sync",
-			Usage: "run a command in a container synchronously",
+			Name:  "sync, s",
+			Usage: "Run the command synchronously",
 		},
 		cli.Int64Flag{
 			Name:  "timeout",
 			Value: 0,
-			Usage: "timeout for the command",
+			Usage: "Timeout in seconds",
 		},
 		cli.BoolFlag{
 			Name:  "tty, t",
-			Usage: "exec a command in a tty",
+			Usage: "Allocate a pseudo-TTY",
 		},
 		cli.BoolFlag{
-			Name:  "stdin, i",
-			Usage: "stream stdin",
+			Name:  "interactive, i",
+			Usage: "Keep STDIN open",
 		},
 	},
 	Action: func(context *cli.Context) error {

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -19,29 +19,25 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/Sirupsen/logrus"
+	units "github.com/docker/go-units"
 	"github.com/urfave/cli"
 	"golang.org/x/net/context"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
-var imageCommand = cli.Command{
-	Name:  "image",
-	Usage: "manage images",
-	Subcommands: []cli.Command{
-		pullImageCommand,
-		listImageCommand,
-		imageStatusCommand,
-		removeImageCommand,
-	},
-	After: closeConnection,
-}
+const (
+	// truncatedImageIDLen is the truncated length of imageID
+	truncatedImageIDLen = 13
+)
 
 var pullImageCommand = cli.Command{
 	Name:  "pull",
-	Usage: "pull an image",
+	Usage: "Pull an image from a registry",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "creds",
@@ -74,22 +70,27 @@ var pullImageCommand = cli.Command{
 		if err != nil {
 			return fmt.Errorf("pulling image failed: %v", err)
 		}
-		fmt.Println(r.ImageRef)
+		fmt.Printf("Image is update to date for %s\n", r.ImageRef)
 		return nil
 	},
 }
 
 var listImageCommand = cli.Command{
-	Name:  "ls",
-	Usage: "list images",
+	Name:      "images",
+	Usage:     "List images",
+	ArgsUsage: "[REPOSITORY[:TAG]]",
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "verbose, v",
-			Usage: "show verbose info for images",
+			Usage: "Show verbose info for images",
 		},
 		cli.BoolFlag{
-			Name:  "quiet",
-			Usage: "list only image IDs",
+			Name:  "quiet, q",
+			Usage: "Only show image IDs",
+		},
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "Output format, One of: json|yaml|table",
 		},
 	},
 	Action: func(context *cli.Context) error {
@@ -102,6 +103,16 @@ var listImageCommand = cli.Command{
 		if err != nil {
 			return fmt.Errorf("listing images failed: %v", err)
 		}
+
+		switch context.String("output") {
+		case "json":
+			return outputJson(r.Images)
+		case "yaml":
+			return outputYaml(r.Images)
+		}
+
+		// output in table format by default.
+		w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 		verbose := context.Bool("verbose")
 		printHeader := true
 		for _, image := range r.Images {
@@ -112,13 +123,16 @@ var listImageCommand = cli.Command{
 			if !verbose {
 				if printHeader {
 					printHeader = false
-					fmt.Println("IMAGE\tIMAGE ID\tSIZE")
+					fmt.Fprintln(w, "IMAGE\tTAG\tIMAGE ID\tSIZE")
 				}
 				repoTags := "<none>"
 				if image.RepoTags != nil {
 					repoTags = image.RepoTags[0]
 				}
-				fmt.Printf("%s\t%s\t%d\n", repoTags, image.Id, image.GetSize_())
+				repoTagsPair := strings.Split(repoTags, ":")
+				size := units.HumanSizeWithPrecision(float64(image.GetSize_()), 3)
+				trunctedImage := strings.TrimPrefix(image.Id, "sha256:")[:truncatedImageIDLen]
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", repoTagsPair[0], repoTagsPair[1], trunctedImage, size)
 				continue
 			}
 			fmt.Printf("ID: %s\n", image.Id)
@@ -138,14 +152,21 @@ var listImageCommand = cli.Command{
 				fmt.Printf("Username: %v\n\n", image.Username)
 			}
 		}
+		w.Flush()
 		return nil
 	},
 }
 
 var imageStatusCommand = cli.Command{
-	Name:      "status",
-	Usage:     "return the status of an image",
+	Name:      "inspecti",
+	Usage:     "Return the status of an image",
 	ArgsUsage: "IMAGEID",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "Output format, One of: json|yaml|table",
+		},
+	},
 	Action: func(context *cli.Context) error {
 		id := context.Args().First()
 		if id == "" {
@@ -165,6 +186,16 @@ var imageStatusCommand = cli.Command{
 		if image == nil {
 			return fmt.Errorf("no such image present")
 		}
+
+		switch context.String("output") {
+		case "json":
+			return outputJson(r.Image)
+
+		case "yaml":
+			return outputYaml(r.Image)
+		}
+
+		// output in table format by default.
 		fmt.Printf("ID: %s\n", image.Id)
 		for _, tag := range image.RepoTags {
 			fmt.Printf("Tag: %s\n", tag)
@@ -172,13 +203,16 @@ var imageStatusCommand = cli.Command{
 		for _, digest := range image.RepoDigests {
 			fmt.Printf("Digest: %s\n", digest)
 		}
-		fmt.Printf("Size: %d\n", image.Size_)
+		size := units.HumanSizeWithPrecision(float64(image.GetSize_()), 3)
+		fmt.Printf("Size: %s\n", size)
+
 		return nil
 	},
 }
+
 var removeImageCommand = cli.Command{
-	Name:      "rm",
-	Usage:     "remove an image",
+	Name:      "rmi",
+	Usage:     "Remove an image",
 	ArgsUsage: "IMAGEID",
 	Action: func(context *cli.Context) error {
 		id := context.Args().First()
@@ -190,10 +224,22 @@ var removeImageCommand = cli.Command{
 			return err
 		}
 
-		r, err := RemoveImage(imageClient, id)
-		logrus.Debugf("RemoveImageResponse: %v", r)
+		status, err := ImageStatus(imageClient, id)
+		logrus.Debugf("Get image status: %v", status)
 		if err != nil {
-			return fmt.Errorf("removing the image %q failed: %v", id, err)
+			return fmt.Errorf("image status request failed: %v", err)
+		}
+		if status.Image == nil {
+			return fmt.Errorf("no such image %s", id)
+		}
+
+		r, err := RemoveImage(imageClient, id)
+		logrus.Debugf("Get remove image response: %v", r)
+		if err != nil {
+			return fmt.Errorf("error of removing image %q: %v", id, err)
+		}
+		for _, repoTag := range status.Image.RepoTags {
+			fmt.Printf("Deleted: %s\n", repoTag)
 		}
 		return nil
 	},

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -106,9 +106,9 @@ var listImageCommand = cli.Command{
 
 		switch context.String("output") {
 		case "json":
-			return outputJson(r.Images)
+			return outputJSON(r.Images)
 		case "yaml":
-			return outputYaml(r.Images)
+			return outputYAML(r.Images)
 		}
 
 		// output in table format by default.
@@ -189,10 +189,10 @@ var imageStatusCommand = cli.Command{
 
 		switch context.String("output") {
 		case "json":
-			return outputJson(r.Image)
+			return outputJSON(r.Image)
 
 		case "yaml":
-			return outputYaml(r.Image)
+			return outputYAML(r.Image)
 		}
 
 		// output in table format by default.

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -25,13 +25,15 @@ import (
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
+const (
+	criClientVersion = "v1alpha1"
+)
+
 var runtimeVersionCommand = cli.Command{
 	Name:  "info",
-	Usage: "get runtime version information",
+	Usage: "Display runtime version information",
 	Action: func(context *cli.Context) error {
-		// Test RuntimeServiceClient.Version
-		version := "v1alpha1"
-		err := Version(runtimeClient, version)
+		err := Version(runtimeClient, criClientVersion)
 		if err != nil {
 			return fmt.Errorf("Getting the runtime version failed: %v", err)
 		}

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -55,6 +55,7 @@ func getRuntimeClientConnection(context *cli.Context) (*grpc.ClientConn, error) 
 	}
 	return conn, nil
 }
+
 func getImageClientConnection(context *cli.Context) (*grpc.ClientConn, error) {
 	if ImageEndpoint == "" {
 		if RuntimeEndpoint == "" {
@@ -80,11 +81,23 @@ func main() {
 
 	app.Commands = []cli.Command{
 		runtimeVersionCommand,
-		runtimePodSandboxCommand,
-		runtimeContainerCommand,
+		runPodSandboxCommand,
+		stopPodSandboxCommand,
+		removePodSandboxCommand,
+		podSandboxStatusCommand,
+		listPodSandboxCommand,
+		createContainerCommand,
+		startContainerCommand,
+		stopContainerCommand,
+		removeContainerCommand,
+		containerStatusCommand,
+		listContainersCommand,
 		runtimeStatusCommand,
 		runtimeAttachCommand,
-		imageCommand,
+		pullImageCommand,
+		listImageCommand,
+		imageStatusCommand,
+		removeImageCommand,
 		runtimeExecCommand,
 		runtimePortForwardCommand,
 		logsCommand,
@@ -92,35 +105,35 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:   "config-file, c",
+			Name:   "config, c",
 			EnvVar: "CRI_CONFIG_FILE",
 			Value:  "",
-			Usage:  "config file for crictl",
+			Usage:  "Location of the client config file",
 		},
 		cli.StringFlag{
 			Name:   "runtime-endpoint, r",
 			EnvVar: "CRI_RUNTIME_ENDPOINT",
 			Value:  "/var/run/dockershim.sock",
-			Usage:  "endpoint for CRI container runtime",
+			Usage:  "Endpoint of CRI container runtime service",
 		},
 		cli.StringFlag{
 			Name:   "image-endpoint, i",
 			EnvVar: "CRI_IMAGE_ENDPOINT",
-			Usage:  "endpoint for CRI image service",
+			Usage:  "Endpoint of CRI image manager service",
 		},
 		cli.DurationFlag{
-			Name:  "timeout",
+			Name:  "timeout, t",
 			Value: defaultTimeout,
-			Usage: "Timeout of connecting to server",
+			Usage: "Timeout of connecting to the server",
 		},
 		cli.BoolFlag{
-			Name:  "debug",
-			Usage: "Enable debug output",
+			Name:  "debug, D",
+			Usage: "Enable debug mode",
 		},
 	}
 
 	app.Before = func(context *cli.Context) error {
-		configFile := context.GlobalString("config-file")
+		configFile := context.GlobalString("config")
 		if configFile == "" {
 			RuntimeEndpoint = context.GlobalString("runtime-endpoint")
 			ImageEndpoint = context.GlobalString("image-endpoint")

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -33,9 +33,9 @@ import (
 )
 
 var runtimePortForwardCommand = cli.Command{
-	Name:      "portforward",
-	Usage:     "forword ports from a sandbox",
-	ArgsUsage: "sandboxID [LOCAL_PORT:]REMOTE_PORT",
+	Name:      "port-forward",
+	Usage:     "Forward local port to a sandbox",
+	ArgsUsage: "SANDBOX [LOCAL_PORT:]REMOTE_PORT",
 	Action: func(context *cli.Context) error {
 		args := context.Args()
 		if len(args) < 2 {

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -256,10 +256,10 @@ func PodSandboxStatus(client pb.RuntimeServiceClient, ID, output string) error {
 
 	switch output {
 	case "json":
-		return outputJson(r.Status)
+		return outputJSON(r.Status)
 
 	case "yaml":
-		return outputYaml(r.Status)
+		return outputYAML(r.Status)
 	}
 
 	// output in table format by default.
@@ -334,10 +334,10 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 
 	switch opts.output {
 	case "json":
-		return outputJson(r.Items)
+		return outputJSON(r.Items)
 
 	case "yaml":
-		return outputYaml(r.Items)
+		return outputYAML(r.Items)
 	}
 
 	// output in table format by default.

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -19,7 +19,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -28,23 +30,9 @@ import (
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
-var runtimePodSandboxCommand = cli.Command{
-	Name:    "sandbox",
-	Usage:   "manage sandboxes",
-	Aliases: []string{"sb"},
-	Subcommands: []cli.Command{
-		runPodSandboxCommand,
-		stopPodSandboxCommand,
-		removePodSandboxCommand,
-		podSandboxStatusCommand,
-		listPodSandboxCommand,
-	},
-	After: closeConnection,
-}
-
 var runPodSandboxCommand = cli.Command{
-	Name:      "run",
-	Usage:     "run a sandbox",
+	Name:      "runs",
+	Usage:     "Run a new sandbox",
 	ArgsUsage: "sandbox-config.json",
 	Action: func(context *cli.Context) error {
 		sandboxSpec := context.Args().First()
@@ -71,9 +59,9 @@ var runPodSandboxCommand = cli.Command{
 }
 
 var stopPodSandboxCommand = cli.Command{
-	Name:      "stop",
-	Usage:     "stop the sandbox",
-	ArgsUsage: "sandboxID",
+	Name:      "stops",
+	Usage:     "Stop a running sandbox",
+	ArgsUsage: "SANDBOX",
 	Action: func(context *cli.Context) error {
 		id := context.Args().First()
 		if id == "" {
@@ -93,9 +81,9 @@ var stopPodSandboxCommand = cli.Command{
 }
 
 var removePodSandboxCommand = cli.Command{
-	Name:      "rm",
-	Usage:     "remove the sandbox",
-	ArgsUsage: "sandboxID",
+	Name:      "rms",
+	Usage:     "Remove a sandbox",
+	ArgsUsage: "SANDBOX",
 	Action: func(context *cli.Context) error {
 		id := context.Args().First()
 		if id == "" {
@@ -115,9 +103,15 @@ var removePodSandboxCommand = cli.Command{
 }
 
 var podSandboxStatusCommand = cli.Command{
-	Name:      "status",
-	Usage:     "get status of the sandbox",
-	ArgsUsage: "sandboxID",
+	Name:      "inspects",
+	Usage:     "Display the status of a sandbox",
+	ArgsUsage: "SANDBOX",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "Output format, One of: json|yaml|table",
+		},
+	},
 	Action: func(context *cli.Context) error {
 		id := context.Args().First()
 		if id == "" {
@@ -128,7 +122,7 @@ var podSandboxStatusCommand = cli.Command{
 			return err
 		}
 
-		err := PodSandboxStatus(runtimeClient, id)
+		err := PodSandboxStatus(runtimeClient, id, context.String("output"))
 		if err != nil {
 			return fmt.Errorf("getting the pod sandbox status failed: %v", err)
 		}
@@ -137,8 +131,8 @@ var podSandboxStatusCommand = cli.Command{
 }
 
 var listPodSandboxCommand = cli.Command{
-	Name:  "ls",
-	Usage: "list sandboxes",
+	Name:  "sandboxes",
+	Usage: "List sandboxes",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",
@@ -162,6 +156,10 @@ var listPodSandboxCommand = cli.Command{
 			Name:  "quiet",
 			Usage: "list only sandbox IDs",
 		},
+		cli.StringFlag{
+			Name:  "output, o",
+			Usage: "Output format, One of: json|yaml|table",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := getRuntimeClient(context); err != nil {
@@ -174,6 +172,7 @@ var listPodSandboxCommand = cli.Command{
 			verbose: context.Bool("verbose"),
 			labels:  make(map[string]string),
 			quiet:   context.Bool("quiet"),
+			output:  context.String("output"),
 		}
 
 		for _, l := range context.StringSlice("label") {
@@ -219,7 +218,8 @@ func StopPodSandbox(client pb.RuntimeServiceClient, ID string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Stop sandbox success ID: %s\n", ID)
+
+	fmt.Printf("Stopped sandbox %s", ID)
 	return nil
 }
 
@@ -236,13 +236,13 @@ func RemovePodSandbox(client pb.RuntimeServiceClient, ID string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Remove sandbox success ID: %s\n", ID)
+	fmt.Printf("Removed sandbox %s\n", ID)
 	return nil
 }
 
 // PodSandboxStatus sends a PodSandboxStatusRequest to the server, and parses
 // the returned PodSandboxStatusResponse.
-func PodSandboxStatus(client pb.RuntimeServiceClient, ID string) error {
+func PodSandboxStatus(client pb.RuntimeServiceClient, ID, output string) error {
 	if ID == "" {
 		return fmt.Errorf("ID cannot be empty")
 	}
@@ -253,6 +253,16 @@ func PodSandboxStatus(client pb.RuntimeServiceClient, ID string) error {
 	if err != nil {
 		return err
 	}
+
+	switch output {
+	case "json":
+		return outputJson(r.Status)
+
+	case "yaml":
+		return outputYaml(r.Status)
+	}
+
+	// output in table format by default.
 	fmt.Printf("ID: %s\n", r.Status.Id)
 	if r.Status.Metadata != nil {
 		if r.Status.Metadata.Name != "" {
@@ -321,7 +331,18 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 	if err != nil {
 		return err
 	}
+
+	switch opts.output {
+	case "json":
+		return outputJson(r.Items)
+
+	case "yaml":
+		return outputYaml(r.Items)
+	}
+
+	// output in table format by default.
 	printHeader := true
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 	for _, pod := range r.Items {
 		if opts.quiet {
 			fmt.Printf("%s\n", pod.Id)
@@ -330,9 +351,10 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 		if !opts.verbose {
 			if printHeader {
 				printHeader = false
-				fmt.Println("SANDBOX ID\tNAME\tSTATE")
+				fmt.Fprintln(w, "SANDBOX ID\tNAME\tSTATE")
 			}
-			fmt.Printf("%s\t%s\t%s\n", pod.Id, pod.Metadata.Name, pod.State)
+
+			fmt.Fprintf(w, "%s\t%s\t%s\n", pod.Id, pod.Metadata.Name, pod.State)
 			continue
 		}
 
@@ -368,5 +390,7 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 		}
 		fmt.Println()
 	}
+
+	w.Flush()
 	return nil
 }

--- a/cmd/crictl/status.go
+++ b/cmd/crictl/status.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -26,8 +28,9 @@ import (
 )
 
 var runtimeStatusCommand = cli.Command{
-	Name:  "status",
-	Usage: "get the status of runtime",
+	Name:      "status",
+	Usage:     "Display status of the container runtime",
+	ArgsUsage: "",
 	Action: func(context *cli.Context) error {
 		err := Status(runtimeClient)
 		if err != nil {
@@ -48,9 +51,12 @@ func Status(client pb.RuntimeServiceClient) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("CONDITION\tSTATUS\tREASON\tMESSAGE")
+
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
+	fmt.Fprintln(w, "CONDITION\tSTATUS\tREASON\tMESSAGE")
 	for _, c := range r.GetStatus().GetConditions() {
-		fmt.Printf("%s\t%v\t%s\t%s\n", c.Type, c.Status, c.Reason, c.Message)
+		fmt.Fprintf(w, "%s\t%v\t%s\t%s\n", c.Type, c.Status, c.Reason, c.Message)
 	}
+	w.Flush()
 	return nil
 }

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -155,22 +155,22 @@ func closeConnection(context *cli.Context) error {
 	return conn.Close()
 }
 
-func outputJson(v interface{}) error {
-	marshaledJson, err := json.MarshalIndent(v, "", "  ")
+func outputJSON(v interface{}) error {
+	marshaledJSON, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(marshaledJson))
+	fmt.Println(string(marshaledJSON))
 	return nil
 }
 
-func outputYaml(v interface{}) error {
-	marshaledyaml, err := yaml.Marshal(v)
+func outputYAML(v interface{}) error {
+	marshaledYAML, err := yaml.Marshal(v)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(string(marshaledyaml))
+	fmt.Println(string(marshaledYAML))
 	return nil
 }

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/ghodss/yaml"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -44,6 +45,8 @@ type listOptions struct {
 	labels map[string]string
 	// quiet is for listing just container/sandbox/image IDs
 	quiet bool
+	// output format
+	output string
 }
 
 type execOptions struct {
@@ -150,4 +153,24 @@ func closeConnection(context *cli.Context) error {
 	}
 
 	return conn.Close()
+}
+
+func outputJson(v interface{}) error {
+	marshaledJson, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(marshaledJson))
+	return nil
+}
+
+func outputYaml(v interface{}) error {
+	marshaledyaml, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(marshaledyaml))
+	return nil
 }

--- a/vendor/github.com/docker/go-units/CONTRIBUTING.md
+++ b/vendor/github.com/docker/go-units/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to go-units
+
+Want to hack on go-units? Awesome! Here are instructions to get you started.
+
+go-units is a part of the [Docker](https://www.docker.com) project, and follows
+the same rules and principles. If you're already familiar with the way
+Docker does things, you'll feel right at home.
+
+Otherwise, go read Docker's
+[contributions guidelines](https://github.com/docker/docker/blob/master/CONTRIBUTING.md),
+[issue triaging](https://github.com/docker/docker/blob/master/project/ISSUE-TRIAGE.md),
+[review process](https://github.com/docker/docker/blob/master/project/REVIEWING.md) and
+[branches and tags](https://github.com/docker/docker/blob/master/project/BRANCHES-AND-TAGS.md).
+
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your
+signature certifies that you wrote the patch or otherwise have the right to pass
+it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/vendor/github.com/docker/go-units/LICENSE
+++ b/vendor/github.com/docker/go-units/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/docker/go-units/MAINTAINERS
+++ b/vendor/github.com/docker/go-units/MAINTAINERS
@@ -1,0 +1,27 @@
+# go-connections maintainers file
+#
+# This file describes who runs the docker/go-connections project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"calavera",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+	[people.calavera]
+	Name = "David Calavera"
+	Email = "david.calavera@gmail.com"
+	GitHub = "calavera"

--- a/vendor/github.com/docker/go-units/README.md
+++ b/vendor/github.com/docker/go-units/README.md
@@ -1,0 +1,16 @@
+[![GoDoc](https://godoc.org/github.com/docker/go-units?status.svg)](https://godoc.org/github.com/docker/go-units)
+
+# Introduction
+
+go-units is a library to transform human friendly measurements into machine friendly values.
+
+## Usage
+
+See the [docs in godoc](https://godoc.org/github.com/docker/go-units) for examples and documentation.
+
+## Copyright and license
+
+Copyright © 2015 Docker, Inc.
+
+go-units is licensed under the Apache License, Version 2.0.
+See [LICENSE](LICENSE) for the full text of the license.

--- a/vendor/github.com/docker/go-units/circle.yml
+++ b/vendor/github.com/docker/go-units/circle.yml
@@ -1,0 +1,11 @@
+dependencies:
+  post:
+    # install golint
+    - go get github.com/golang/lint/golint
+
+test:
+  pre:
+    # run analysis before tests
+    - go vet ./...
+    - test -z "$(golint ./... | tee /dev/stderr)"
+    - test -z "$(gofmt -s -l . | tee /dev/stderr)"

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -1,0 +1,35 @@
+// Package units provides helper function to parse and print size and time units
+// in human-readable format.
+package units
+
+import (
+	"fmt"
+	"time"
+)
+
+// HumanDuration returns a human-readable approximation of a duration
+// (eg. "About a minute", "4 hours ago", etc.).
+func HumanDuration(d time.Duration) string {
+	if seconds := int(d.Seconds()); seconds < 1 {
+		return "Less than a second"
+	} else if seconds == 1 {
+		return "1 second"
+	} else if seconds < 60 {
+		return fmt.Sprintf("%d seconds", seconds)
+	} else if minutes := int(d.Minutes()); minutes == 1 {
+		return "About a minute"
+	} else if minutes < 46 {
+		return fmt.Sprintf("%d minutes", minutes)
+	} else if hours := int(d.Hours() + 0.5); hours == 1 {
+		return "About an hour"
+	} else if hours < 48 {
+		return fmt.Sprintf("%d hours", hours)
+	} else if hours < 24*7*2 {
+		return fmt.Sprintf("%d days", hours/24)
+	} else if hours < 24*30*2 {
+		return fmt.Sprintf("%d weeks", hours/24/7)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%d months", hours/24/30)
+	}
+	return fmt.Sprintf("%d years", int(d.Hours())/24/365)
+}

--- a/vendor/github.com/docker/go-units/size.go
+++ b/vendor/github.com/docker/go-units/size.go
@@ -1,0 +1,108 @@
+package units
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// See: http://en.wikipedia.org/wiki/Binary_prefix
+const (
+	// Decimal
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	// Binary
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+)
+
+type unitMap map[string]int64
+
+var (
+	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
+	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
+)
+
+var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+
+func getSizeAndUnit(size float64, base float64, _map []string) (float64, string) {
+	i := 0
+	unitsLimit := len(_map) - 1
+	for size >= base && i < unitsLimit {
+		size = size / base
+		i++
+	}
+	return size, _map[i]
+}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	size, unit := getSizeAndUnit(size, base, _map)
+	return fmt.Sprintf(format, size, unit)
+}
+
+// HumanSizeWithPrecision allows the size to be in any precision,
+// instead of 4 digit precision used in units.HumanSize.
+func HumanSizeWithPrecision(size float64, precision int) string {
+	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
+	return fmt.Sprintf("%.*g%s", precision, size, unit)
+}
+
+// HumanSize returns a human-readable approximation of a size
+// capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
+func HumanSize(size float64) string {
+	return HumanSizeWithPrecision(size, 4)
+}
+
+// BytesSize returns a human-readable size in bytes, kibibytes,
+// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+func BytesSize(size float64) string {
+	return CustomSize("%.4g%s", size, 1024.0, binaryAbbrs)
+}
+
+// FromHumanSize returns an integer from a human-readable specification of a
+// size using SI standard (eg. "44kB", "17MB").
+func FromHumanSize(size string) (int64, error) {
+	return parseSize(size, decimalMap)
+}
+
+// RAMInBytes parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (int64, error) {
+	return parseSize(size, binaryMap)
+}
+
+// Parses the human-readable size string into the amount it represents.
+func parseSize(sizeStr string, uMap unitMap) (int64, error) {
+	matches := sizeRegex.FindStringSubmatch(sizeStr)
+	if len(matches) != 4 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+
+	size, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return -1, err
+	}
+
+	unitPrefix := strings.ToLower(matches[3])
+	if mul, ok := uMap[unitPrefix]; ok {
+		size *= float64(mul)
+	}
+
+	return int64(size), nil
+}

--- a/vendor/github.com/docker/go-units/ulimit.go
+++ b/vendor/github.com/docker/go-units/ulimit.go
@@ -1,0 +1,118 @@
+package units
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Ulimit is a human friendly version of Rlimit.
+type Ulimit struct {
+	Name string
+	Hard int64
+	Soft int64
+}
+
+// Rlimit specifies the resource limits, such as max open files.
+type Rlimit struct {
+	Type int    `json:"type,omitempty"`
+	Hard uint64 `json:"hard,omitempty"`
+	Soft uint64 `json:"soft,omitempty"`
+}
+
+const (
+	// magic numbers for making the syscall
+	// some of these are defined in the syscall package, but not all.
+	// Also since Windows client doesn't get access to the syscall package, need to
+	//	define these here
+	rlimitAs         = 9
+	rlimitCore       = 4
+	rlimitCPU        = 0
+	rlimitData       = 2
+	rlimitFsize      = 1
+	rlimitLocks      = 10
+	rlimitMemlock    = 8
+	rlimitMsgqueue   = 12
+	rlimitNice       = 13
+	rlimitNofile     = 7
+	rlimitNproc      = 6
+	rlimitRss        = 5
+	rlimitRtprio     = 14
+	rlimitRttime     = 15
+	rlimitSigpending = 11
+	rlimitStack      = 3
+)
+
+var ulimitNameMapping = map[string]int{
+	//"as":         rlimitAs, // Disabled since this doesn't seem usable with the way Docker inits a container.
+	"core":       rlimitCore,
+	"cpu":        rlimitCPU,
+	"data":       rlimitData,
+	"fsize":      rlimitFsize,
+	"locks":      rlimitLocks,
+	"memlock":    rlimitMemlock,
+	"msgqueue":   rlimitMsgqueue,
+	"nice":       rlimitNice,
+	"nofile":     rlimitNofile,
+	"nproc":      rlimitNproc,
+	"rss":        rlimitRss,
+	"rtprio":     rlimitRtprio,
+	"rttime":     rlimitRttime,
+	"sigpending": rlimitSigpending,
+	"stack":      rlimitStack,
+}
+
+// ParseUlimit parses and returns a Ulimit from the specified string.
+func ParseUlimit(val string) (*Ulimit, error) {
+	parts := strings.SplitN(val, "=", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ulimit argument: %s", val)
+	}
+
+	if _, exists := ulimitNameMapping[parts[0]]; !exists {
+		return nil, fmt.Errorf("invalid ulimit type: %s", parts[0])
+	}
+
+	var (
+		soft int64
+		hard = &soft // default to soft in case no hard was set
+		temp int64
+		err  error
+	)
+	switch limitVals := strings.Split(parts[1], ":"); len(limitVals) {
+	case 2:
+		temp, err = strconv.ParseInt(limitVals[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		hard = &temp
+		fallthrough
+	case 1:
+		soft, err = strconv.ParseInt(limitVals[0], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
+	}
+
+	if soft > *hard {
+		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+	}
+
+	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil
+}
+
+// GetRlimit returns the RLimit corresponding to Ulimit.
+func (u *Ulimit) GetRlimit() (*Rlimit, error) {
+	t, exists := ulimitNameMapping[u.Name]
+	if !exists {
+		return nil, fmt.Errorf("invalid ulimit name %s", u.Name)
+	}
+
+	return &Rlimit{Type: t, Soft: uint64(u.Soft), Hard: uint64(u.Hard)}, nil
+}
+
+func (u *Ulimit) String() string {
+	return fmt.Sprintf("%s=%d:%d", u.Name, u.Soft, u.Hard)
+}


### PR DESCRIPTION
This PR simplifies crictl CLI via 

- move subcommands of sandbox/image/container directly to crictl subcommands
- make default output more human readable, e.g. format timestamp and size
- add output format of yaml and json

```
# crictl --help
NAME:
   crictl - client for CRI

USAGE:
   crictl [global options] command [command options] [arguments...]

VERSION:
   0.1.0

COMMANDS:
     info          Display runtime version information
     runs          Run a new sandbox
     stops         Stop a running sandbox
     rms           Remove a sandbox
     inspects      Display the status of a sandbox
     sandboxes     List sandboxes
     create        Create a new container
     start         Start a stopped container
     stop          Stop a running container
     rm            Remove a container
     inspect       Display the status of a container
     ps            List containers
     status        Display status of the container runtime
     attach        Attach to a running container
     pull          Pull an image from a registry
     images        List images
     inspecti      Return the status of an image
     rmi           Remove an image
     exec          Run a command in a running container
     port-forward  Forward local port to a sandbox
     logs          Fetch the logs of a container
     help, h       Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value            Location of the client config file [$CRI_CONFIG_FILE]
   --runtime-endpoint value, -r value  Endpoint of CRI container runtime service (default: "/var/run/dockershim.sock") [$CRI_RUNTIME_ENDPOINT]
   --image-endpoint value, -i value    Endpoint of CRI image manager service [$CRI_IMAGE_ENDPOINT]
   --timeout value, -t value           Timeout of connecting to the server (default: 10s)
   --debug, -D                         Enable debug mode
   --help, -h                          show help
   --version, -v                       print the version
```

See more usage at docs/crictl.md.