### PR TITLE
Fix portforward test sandbox leak.

### DIFF
--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -55,10 +55,6 @@ var _ = framework.KubeDescribe("Streaming", func() {
 		var podID string
 		var podConfig *runtimeapi.PodSandboxConfig
 
-		BeforeEach(func() {
-			podID, podConfig = framework.CreatePodSandboxForContainer(rc)
-		})
-
 		AfterEach(func() {
 			By("stop PodSandbox")
 			rc.StopPodSandbox(podID)
@@ -67,6 +63,8 @@ var _ = framework.KubeDescribe("Streaming", func() {
 		})
 
 		It("runtime should support exec [Conformance]", func() {
+			podID, podConfig = framework.CreatePodSandboxForContainer(rc)
+
 			By("create a default container")
 			containerID := framework.CreateDefaultContainer(rc, ic, podID, podConfig, "container-for-exec-test")
 
@@ -80,6 +78,8 @@ var _ = framework.KubeDescribe("Streaming", func() {
 		})
 
 		It("runtime should support attach [Conformance]", func() {
+			podID, podConfig = framework.CreatePodSandboxForContainer(rc)
+
 			By("create a default container")
 			containerID := createShellContainer(rc, ic, podID, podConfig, "container-for-attach-test")
 


### PR DESCRIPTION
The 3rd test case created sandbox inside the test, but left sandbox created in `BeforeEach` there forever.
Signed-off-by: Lantao Liu <lantaol@google.com>