### PR TITLE
Set LinuxSandboxSecurityContext as required in config

### DIFF
--- a/pkg/benchmark/pod.go
+++ b/pkg/benchmark/pod.go
@@ -49,7 +49,9 @@ var _ = framework.KubeDescribe("PodSandbox", func() {
 
 			config := &runtimeapi.PodSandboxConfig{
 				Metadata: framework.BuildPodSandboxMetadata(podSandboxName, uid, namespace, framework.DefaultAttempt),
-				Linux:    &runtimeapi.LinuxPodSandboxConfig{},
+				Linux: &runtimeapi.LinuxPodSandboxConfig{
+					SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+				},
 			}
 
 			operation := b.Time("create PodSandbox", func() {

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -126,7 +126,9 @@ func RunDefaultPodSandbox(c internalapi.RuntimeService, prefix string) string {
 
 	config := &runtimeapi.PodSandboxConfig{
 		Metadata: BuildPodSandboxMetadata(podSandboxName, uid, namespace, DefaultAttempt),
-		Linux:    &runtimeapi.LinuxPodSandboxConfig{},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+		},
 	}
 	return RunPodSandbox(c, config)
 }
@@ -155,7 +157,9 @@ func CreatePodSandboxForContainer(c internalapi.RuntimeService) (string, *runtim
 	namespace := DefaultNamespacePrefix + NewUUID()
 	config := &runtimeapi.PodSandboxConfig{
 		Metadata: BuildPodSandboxMetadata(podSandboxName, uid, namespace, DefaultAttempt),
-		Linux:    &runtimeapi.LinuxPodSandboxConfig{},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+		},
 	}
 
 	podID := RunPodSandbox(c, config)

--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -135,7 +135,9 @@ func createPodSandWithDNSConfig(c internalapi.RuntimeService) (string, *runtimea
 			Searches: []string{defaultDNSSearch},
 			Options:  []string{defaultDNSOption},
 		},
-		Linux: &runtimeapi.LinuxPodSandboxConfig{},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+		},
 	}
 
 	podID := framework.RunPodSandbox(c, config)
@@ -150,7 +152,9 @@ func createPodSandboxWithPortMapping(c internalapi.RuntimeService, portMappings 
 	config := &runtimeapi.PodSandboxConfig{
 		Metadata:     framework.BuildPodSandboxMetadata(podSandboxName, uid, namespace, framework.DefaultAttempt),
 		PortMappings: portMappings,
-		Linux:        &runtimeapi.LinuxPodSandboxConfig{},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+		},
 	}
 
 	podID := framework.RunPodSandbox(c, config)

--- a/pkg/validate/pod.go
+++ b/pkg/validate/pod.go
@@ -225,6 +225,9 @@ func createPodSandboxWithLogDirectory(c internalapi.RuntimeService) (string, *ru
 	podConfig := &runtimeapi.PodSandboxConfig{
 		Metadata:     framework.BuildPodSandboxMetadata(podSandboxName, uid, namespace, framework.DefaultAttempt),
 		LogDirectory: podLogPath,
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+		},
 	}
 	return framework.RunPodSandbox(c, podConfig), podConfig, hostPath
 }
@@ -239,7 +242,8 @@ func createSandboxWithSysctls(rc internalapi.RuntimeService, sysctls map[string]
 	podConfig := &runtimeapi.PodSandboxConfig{
 		Metadata: framework.BuildPodSandboxMetadata(podSandboxName, uid, namespace, framework.DefaultAttempt),
 		Linux: &runtimeapi.LinuxPodSandboxConfig{
-			Sysctls: sysctls,
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{},
+			Sysctls:         sysctls,
 		},
 	}
 	return framework.RunPodSandbox(rc, podConfig), podConfig


### PR DESCRIPTION
Kube expects LinuxSandboxSecurityContext to be part of the container
config (i.e. not nil).

This was discussed in issue #151:

https://github.com/kubernetes-incubator/cri-tools/issues/151

Signed-off-by: baude <bbaude@redhat.com>