### PR TITLE
security_context: do not rely on /etc/hosts

### DIFF
--- a/pkg/validate/security_context.go
+++ b/pkg/validate/security_context.go
@@ -482,7 +482,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			podID, containerID = seccompTestContainer(rc, ic, localhost+blockchmodProfilePath)
 
 			By("verify seccomp profile")
-			verifySeccomp(rc, containerID, []string{"chmod", "400", "/etc/hosts"}, true, "Operation not permitted") // seccomp denied
+			verifySeccomp(rc, containerID, []string{"chmod", "400", "/"}, true, "Operation not permitted") // seccomp denied
 		})
 
 		It("should support seccomp default which is unconfined on the container", func() {


### PR DESCRIPTION
It depends on runtime and CNI plugin used when testing. This patch uses
/etc/passwd which should be always available instead.

@feiskyer @Random-Liu @mrunalp @sameo  PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>