### PR TITLE
Port map test - IPv4 only please

### DIFF
--- a/pkg/validate/networking.go
+++ b/pkg/validate/networking.go
@@ -189,7 +189,7 @@ func checkNginxMainPage(c internalapi.RuntimeService, podID string, localHost bo
 
 	url := "http://"
 	if localHost {
-		url += "localhost:" + strconv.Itoa(int(nginxHostPort))
+		url += "127.0.0.1:" + strconv.Itoa(int(nginxHostPort))
 	} else {
 		status := getPodSandboxStatus(c, podID)
 		Expect(status.GetNetwork()).NotTo(BeNil(), "The network in status should not be nil.")


### PR DESCRIPTION
When checking from loopback addresses, only IPv4 addresses work because no route_localnet flag is available for IPv6. 
This is for cases that do not use a user land proxy for port mapping but use SNAT/DNAT rules e.g. [cni portmap](https://github.com/containernetworking/plugins/tree/master/plugins/meta/portmap)

/cc @mrunalp 