### PR TITLE
Support using sandbox name for sandbox operating

### DIFF
--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -556,7 +556,8 @@ func ListContainers(client pb.RuntimeServiceClient, opts listOptions) error {
 		createdAt := time.Unix(0, c.CreatedAt)
 		ctm := units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 		if !opts.verbose {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Id, ctm, c.State, c.GetMetadata().GetName())
+			truncatedID := strings.TrimPrefix(c.Id, "")[:truncatedIDLen]
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", truncatedID, ctm, c.State, c.GetMetadata().GetName())
 			continue
 		}
 

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -31,11 +31,6 @@ import (
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
-const (
-	// truncatedImageIDLen is the truncated length of imageID
-	truncatedImageIDLen = 13
-)
-
 type imageByRef []*pb.Image
 
 func (a imageByRef) Len() int      { return len(a) }
@@ -151,7 +146,7 @@ var listImageCommand = cli.Command{
 				imageName, repoDigest := normalizeRepoDigest(image.RepoDigests)
 				repoTagPairs := normalizeRepoTagPair(image.RepoTags, imageName)
 				size := units.HumanSizeWithPrecision(float64(image.GetSize_()), 3)
-				trunctedImage := strings.TrimPrefix(image.Id, "sha256:")[:truncatedImageIDLen]
+				trunctedImage := strings.TrimPrefix(image.Id, "sha256:")[:truncatedIDLen]
 				for _, repoTagPair := range repoTagPairs {
 					if showDigest {
 						fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", repoTagPair[0], repoTagPair[1], repoDigest, trunctedImage, size)

--- a/cmd/crictl/util.go
+++ b/cmd/crictl/util.go
@@ -30,6 +30,11 @@ import (
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
+const (
+	// truncatedImageIDLen is the truncated length of imageID
+	truncatedIDLen = 13
+)
+
 var runtimeClient pb.RuntimeServiceClient
 var imageClient pb.ImageServiceClient
 var conn *grpc.ClientConn


### PR DESCRIPTION
- Show `namespace` in `table` format output of `crictl sandboxes`
- Support using sandbox name for `inspects`, `stops` and `rms`.

Example:
Show `namespace`:
```bash
# crictl sandboxes
SANDBOX ID                                                         NAME                STATE               NAMESPACE
432374d9dfa61d8768668784e9d5392159c8b87810628fefe2871b9233ff0187   busybox             SANDBOX_READY       myq
41555a4bd665dd92078701eb8cbd84723c9257825b1219240de3292343316e3f   busybox             SANDBOX_READY       default
cce6f4f601d4494f9ea2aba48c36b70fea107d9e047e8916052348a128ad51e2   kube-proxy-gwb2k    SANDBOX_READY       kube-system
```

Get the status of a sandbox by sandbox name:
```bash
# crictl inspects busybox -n myq
ID: 432374d9dfa61d8768668784e9d5392159c8b87810628fefe2871b9233ff0187
Name: busybox
UID: 8fed396c-bf74-11e7-bd9d-5254007ee9b4
Namespace: myq
Attempt: 0
Status: SANDBOX_READY
Created: 2017-11-02 10:19:28.555867171 +0800 CST
IP Address: 10.88.0.88
Labels:
	io.kubernetes.pod.name -> busybox
	io.kubernetes.pod.namespace -> myq
	io.kubernetes.pod.uid -> 8fed396c-bf74-11e7-bd9d-5254007ee9b4
Annotations:
	kubernetes.io/config.seen -> 2017-11-02T10:19:28.137670526+08:00
	kubernetes.io/config.source -> api
```
Get the status of a sandbox by sandbox ID:
```bash
# crictl inspects 432374d9dfa61d8768668784e9d5392159c8b87810628fefe2871b9233ff0187
ID: 432374d9dfa61d8768668784e9d5392159c8b87810628fefe2871b9233ff0187
Name: busybox
UID: 8fed396c-bf74-11e7-bd9d-5254007ee9b4
Namespace: myq
Attempt: 0
Status: SANDBOX_READY
Created: 2017-11-02 10:19:28.555867171 +0800 CST
IP Address: 10.88.0.88
Labels:
	io.kubernetes.pod.name -> busybox
	io.kubernetes.pod.namespace -> myq
	io.kubernetes.pod.uid -> 8fed396c-bf74-11e7-bd9d-5254007ee9b4
Annotations:
	kubernetes.io/config.seen -> 2017-11-02T10:19:28.137670526+08:00
	kubernetes.io/config.source -> api
```

/cc @feiskyer @Random-Liu 

Signed-off-by: Yanqiang Miao <miao.yanqiang@zte.com.cn>