### PR TITLE
Fix attach and exec.

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -80,6 +80,8 @@ func Attach(client pb.RuntimeServiceClient, opts attachOptions) error {
 		ContainerId: opts.id,
 		Tty:         opts.tty,
 		Stdin:       opts.stdin,
+		Stdout:      true,
+		Stderr:      !opts.tty,
 	}
 	logrus.Debugf("AttachRequest: %v", request)
 	r, err := client.Attach(context.Background(), request)

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -71,7 +71,7 @@ var runtimeExecCommand = cli.Command{
 			id:      context.Args().First(),
 			timeout: context.Int64("timeout"),
 			tty:     context.Bool("tty"),
-			stdin:   context.Bool("stdin"),
+			stdin:   context.Bool("interactive"),
 			cmd:     context.Args()[1:],
 		}
 		if context.Bool("sync") {
@@ -120,6 +120,8 @@ func Exec(client pb.RuntimeServiceClient, opts execOptions) error {
 		Cmd:         opts.cmd,
 		Tty:         opts.tty,
 		Stdin:       opts.stdin,
+		Stdout:      true,
+		Stderr:      !opts.tty,
 	}
 	logrus.Debugf("ExecRequest: %v", request)
 	r, err := client.Exec(context.Background(), request)


### PR DESCRIPTION
New CRI fields `Stdout` and `Stderr` are not set.
And `interactive` is not used.

@feiskyer 
Signed-off-by: Lantao Liu <lantaol@google.com>