### PR TITLE
Create bindir in install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ clean:
 binaries: critest crictl
 
 install: check-gopath
+	mkdir -p $(BINDIR)
 	install -D -m 755 $(GOBINDIR)/bin/critest $(BINDIR)/critest
 	install -D -m 755 $(GOBINDIR)/bin/crictl $(BINDIR)/crictl
 


### PR DESCRIPTION
When running install if the destination directory does not exist,
install will fail. To avoid this create the BINDIR first.