### PR TITLE
stop sandbox return with enter.

### DIFF
--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -252,7 +252,7 @@ func StopPodSandbox(client pb.RuntimeServiceClient, ID string) error {
 		return err
 	}
 
-	fmt.Printf("Stopped sandbox %s", ID)
+	fmt.Printf("Stopped sandbox %s\n", ID)
 	return nil
 }
 


### PR DESCRIPTION
cmdline stop sandbox return with enter. 


Signed-off-by: CuiHaozhi <cuihaozhi@chinacloud.com.cn>