### PR TITLE
ci: change go version to 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.8.x
+  - 1.9.x
 
 go_import_path: github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
Kubernetes requires go1.9.1 or greater
https://github.com/kubernetes/kubernetes/pull/55301

Signed-off-by: CuiHaozhi <cuihaozhi@chinacloud.com.cn>