### PR TITLE
cmd: crictl: add a config command

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -109,6 +109,7 @@ func main() {
 		stopContainerCommand,
 		stopPodSandboxCommand,
 		updateContainerCommand,
+		configCommand,
 	}
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
This is a fairly simple patch that just adds a `config` command to get and set configurations similar to `git config`.
This would be very needed for higher level commands like `kubeadm` in order to gather stuff like the `runtime-endpoint` to query.

@feiskyer @Random-Liu PTAL

```
$ crictl config --get runtime-endpoint
/var/run/crio.sock

$ crictl config runtime-endpoint /var/run/dockershim.sock

$ crictl config --get runtime-endpoint
/var/run/dockershim.sock

$ cat /etc/crictl.yaml
runtime-endpoint: /var/run/dockershim.sock
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>