### PR TITLE
validate: do not check NET_ADMIN with ip link add

### DIFF
--- a/pkg/validate/security_context.go
+++ b/pkg/validate/security_context.go
@@ -825,7 +825,7 @@ func createPrivilegedContainer(rc internalapi.RuntimeService, ic internalapi.Ima
 
 // checkNetworkManagement checks the container's network management works fine.
 func checkNetworkManagement(rc internalapi.RuntimeService, containerID string, manageable bool) {
-	cmd := []string{"ip", "link", "add", "dummy0", "type", "dummy"}
+	cmd := []string{"brctl", "addbr", "foobar"}
 
 	stdout, stderr, err := rc.ExecSync(containerID, cmd, time.Duration(defaultExecSyncTimeout)*time.Second)
 	msg := fmt.Sprintf("cmd %v, stdout %q, stderr %q", cmd, stdout, stderr)


### PR DESCRIPTION
`ip link add` with the foo driver requires the kernel to be custom compiled with particular `CONFIG_*`. One of our test machines is indeed failing with:
```
RTNETLINK answers: Operation not supported
```
Since the aim is to just check for NET_ADMIN, change the ip link command to just a foo brctl addbr

@feiskyer @Random-Liu @sameo PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>