### PR TITLE
validate: support old ipcmk versions

### DIFF
--- a/pkg/validate/security_context.go
+++ b/pkg/validate/security_context.go
@@ -120,8 +120,8 @@ var _ = framework.KubeDescribe("Security Context", func() {
 
 		It("runtime should support HostIpc is true", func() {
 			By("create shared memory segment on the host")
-			out, err := exec.Command("ipcmk", "-M", "1M").Output()
-			framework.ExpectNoError(err, "failed to execute ipcmk -M 1M")
+			out, err := exec.Command("ipcmk", "-M", "1048576").Output()
+			framework.ExpectNoError(err, "failed to execute ipcmk -M 1048576")
 			rawID := strings.TrimSpace(string(out))
 			segmentID := strings.TrimPrefix(rawID, "Shared memory id: ")
 
@@ -153,8 +153,8 @@ var _ = framework.KubeDescribe("Security Context", func() {
 
 		It("runtime should support HostIpc is false", func() {
 			By("create shared memory segment on the host")
-			out, err := exec.Command("ipcmk", "-M", "1M").Output()
-			framework.ExpectNoError(err, "failed to execute ipcmk -M 1M")
+			out, err := exec.Command("ipcmk", "-M", "1048576").Output()
+			framework.ExpectNoError(err, "failed to execute ipcmk -M 1048576")
 			rawID := strings.TrimSpace(string(out))
 			segmentID := strings.TrimPrefix(rawID, "Shared memory id: ")
 


### PR DESCRIPTION
`ipcmk` fails on RHEL with:
```
ipcmk: failed to parse size: '1MB'
```
Since it's version `2.23.2`. This patch changes the invocation to ipcmk so we can run `critest` on RHEL by using `1024 * 1024`.

@feiskyer @Random-Liu @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>