### PR TITLE
validate: fix container with log test

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -211,10 +211,10 @@ var _ = framework.KubeDescribe("Container", func() {
 
 			By("start container with log")
 			startContainer(rc, containerID)
-			// wait container started and check the status.
+			// wait container exited and check the status.
 			Eventually(func() runtimeapi.ContainerState {
 				return getContainerStatus(rc, containerID).State
-			}, time.Minute, time.Second*4).Should(Equal(runtimeapi.ContainerState_CONTAINER_RUNNING))
+			}, time.Minute, time.Second*4).Should(Equal(runtimeapi.ContainerState_CONTAINER_EXITED))
 
 			By("check the log context")
 			expectedLogMessage := &logMessage{


### PR DESCRIPTION
The command "echo ..." in the container could have been already finished by the time we check conatiner status. There's no reason to check for RUNNING, rather, check EXITED to make sure the container executed and exited and then go ahead and inspect the logs.

@feiskyer @Random-Liu @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>