### PR TITLE
Sort flags for all commands.

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -200,6 +201,12 @@ func main() {
 		}
 		return nil
 	}
+	// sort all flags
+	for _, cmd := range app.Commands {
+		sort.Sort(cli.FlagsByName(cmd.Flags))
+	}
+	sort.Sort(cli.FlagsByName(app.Flags))
+
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)
 	}


### PR DESCRIPTION
Sort all flags.

Before:
```console
$ crictl ps --help
NAME:
   crictl ps - List containers

USAGE:
   crictl ps [command options] [arguments...]

OPTIONS:
   --verbose, -v             Show verbose information for containers
   --id value                Filter by container id
   --sandbox value           Filter by sandbox id
   --state value             Filter by container state
   --label value             Filter by key=value label
   --quiet                   Only display container IDs
   --output value, -o value  Output format, One of: json|yaml|table
   --all, -a                 Show all containers
   --latest, -l              Show recently created container (includes all states)
   --last value, -n value    Show last n recently created containers (includes all states) (default: 0)
   --no-trunc                Show output without truncating the ID
```

After:
```console
$ crictl ps --help
NAME:
   crictl ps - List containers

USAGE:
   crictl ps [command options] [arguments...]

OPTIONS:
   --all, -a                 Show all containers
   --id value                Filter by container id
   --label value             Filter by key=value label
   --last value, -n value    Show last n recently created containers (includes all states) (default: 0)
   --latest, -l              Show recently created container (includes all states)
   --no-trunc                Show output without truncating the ID
   --output value, -o value  Output format, One of: json|yaml|table
   --quiet                   Only display container IDs
   --sandbox value           Filter by sandbox id
   --state value             Filter by container state
   --verbose, -v             Show verbose information for containers
```