### PR TITLE
Rewrite timestamps in container/sandbox status.

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -217,9 +217,13 @@ var imageStatusCommand = cli.Command{
 			output = "json"
 		}
 
+		status, err := protobufObjectToJSON(r.Image)
+		if err != nil {
+			return err
+		}
 		switch output {
 		case "json", "yaml":
-			return outputStatusInfo(r.Image, r.Info, output)
+			return outputStatusInfo(status, r.Info, output)
 		case "table": // table output is after this switch block
 		default:
 			return fmt.Errorf("output option cannot be %s", output)

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -57,5 +57,9 @@ func Info(cliContext *cli.Context, client pb.RuntimeServiceClient) error {
 		return err
 	}
 
-	return outputStatusInfo(r.Status, r.Info, cliContext.String("output"))
+	status, err := protobufObjectToJSON(r.Status)
+	if err != nil {
+		return err
+	}
+	return outputStatusInfo(status, r.Info, cliContext.String("output"))
 }


### PR DESCRIPTION
Rewrite timestamps in status to make it more user friendly. After this change:
```console
$ crictl inspects 6ecc8a386012a
{
  "status": {
    "id": "6ecc8a386012aa3d8cc41e986263a56c039044b7f9dcceda012cc3fc045e58c9",
    "metadata": {
      "attempt": 0,
      "name": "kube-dns-6c857864fb-z88p2",
      "namespace": "kube-system",
      "uid": "64489eae-d610-11e7-8e8b-42010af00002"
    },
    "state": "SANDBOX_NOTREADY",
    "createdAt": "2017-11-30T20:52:44.926737345Z",
    "network": {
      "ip": "10.88.22.12"
    },
    "linux": {
      "namespaces": {
        "options": {
          "hostIpc": false,
          "hostNetwork": false,
          "hostPid": false
        }
      }
    },
    "labels": {
      "io.kubernetes.pod.name": "kube-dns-6c857864fb-z88p2",
      "io.kubernetes.pod.namespace": "kube-system",
      "io.kubernetes.pod.uid": "64489eae-d610-11e7-8e8b-42010af00002",
      "k8s-app": "kube-dns",
      "pod-template-hash": "2741342096"
    },
    "annotations": {
      "kubernetes.io/config.seen": "2017-11-30T20:52:41.854730835Z",
      "kubernetes.io/config.source": "api",
      "scheduler.alpha.kubernetes.io/critical-pod": ""
    }
  }
}
$  crictl inspect 98ad5842a6284 -q
{
  "status": {
    "id": "98ad5842a62844f62d4468c52dbfcc081a08ba25c95c842a967de7058f60dd24",
    "metadata": {
      "attempt": 0,
      "name": "nginx"
    },
    "state": "CONTAINER_EXITED",
    "createdAt": "2017-11-30T21:57:26.038813532Z",
    "startedAt": "2017-11-30T21:57:26.235406355Z",
    "finishedAt": "2017-12-01T20:08:56.523559866Z",
    "exitCode": 255,
    "image": {
      "image": "gcr.io/google-containers/nginx-slim-amd64:0.20"
    },
    "imageRef": "gcr.io/google-containers/nginx-slim-amd64@sha256:6654db6d4028756062edac466454ee5c9cf9b20ef79e35a81e3c840031eb1e2b",
    "reason": "Unknown",
    "message": "",
    "labels": {
      "io.kubernetes.container.name": "nginx",
      "io.kubernetes.pod.name": "nginx",
      "io.kubernetes.pod.namespace": "e2e-tests-kubectl-2jdtb",
      "io.kubernetes.pod.uid": "6ffc887b-d619-11e7-8e8b-42010af00002"
    },
    "annotations": {
      "io.kubernetes.container.hash": "cfada9cb",
      "io.kubernetes.container.ports": "[{\"containerPort\":80,\"protocol\":\"TCP\"}]",
      "io.kubernetes.container.restartCount": "0",
      "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
      "io.kubernetes.container.terminationMessagePolicy": "File",
      "io.kubernetes.pod.terminationGracePeriod": "30"
    },
    "mounts": [
      {
        "containerPath": "/var/run/secrets/kubernetes.io/serviceaccount",
        "hostPath": "/var/lib/kubelet/pods/6ffc887b-d619-11e7-8e8b-42010af00002/volumes/kubernetes.io~secret/default-token-4ztmf",
        "propagation": "PROPAGATION_PRIVATE",
        "readonly": true,
        "selinuxRelabel": false
      },
      {
        "containerPath": "/etc/hosts",
        "hostPath": "/var/lib/kubelet/pods/6ffc887b-d619-11e7-8e8b-42010af00002/etc-hosts",
        "propagation": "PROPAGATION_PRIVATE",
        "readonly": false,
        "selinuxRelabel": false
      },
      {
        "containerPath": "/dev/termination-log",
        "hostPath": "/var/lib/kubelet/pods/6ffc887b-d619-11e7-8e8b-42010af00002/containers/nginx/5f93e895",
        "propagation": "PROPAGATION_PRIVATE",
        "readonly": false,
        "selinuxRelabel": false
      }
    ],
    "logPath": "/var/log/pods/6ffc887b-d619-11e7-8e8b-42010af00002/nginx_0.log"
  }
}
```
Signed-off-by: Lantao Liu <lantaol@google.com>