### PR TITLE
Add no-trunc for `crictl images` and `crictl sandboxes`.

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -105,6 +105,10 @@ var listImageCommand = cli.Command{
 			Name:  "digests",
 			Usage: "Show digests",
 		},
+		cli.BoolFlag{
+			Name:  "no-trunc",
+			Usage: "Show output without truncating the ID",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		if err := getImageClient(context); err != nil {
@@ -129,6 +133,7 @@ var listImageCommand = cli.Command{
 		verbose := context.Bool("verbose")
 		showDigest := context.Bool("digests")
 		quiet := context.Bool("quiet")
+		noTrunc := context.Bool("no-trunc")
 		if !verbose && !quiet {
 			if showDigest {
 				fmt.Fprintln(w, "IMAGE\tTAG\tDIGEST\tIMAGE ID\tSIZE")
@@ -141,17 +146,19 @@ var listImageCommand = cli.Command{
 				fmt.Printf("%s\n", image.Id)
 				continue
 			}
-
 			if !verbose {
 				imageName, repoDigest := normalizeRepoDigest(image.RepoDigests)
 				repoTagPairs := normalizeRepoTagPair(image.RepoTags, imageName)
 				size := units.HumanSizeWithPrecision(float64(image.GetSize_()), 3)
-				trunctedImage := strings.TrimPrefix(image.Id, "sha256:")[:truncatedIDLen]
+				id := image.Id
+				if !noTrunc {
+					id = strings.TrimPrefix(image.Id, "sha256:")[:truncatedIDLen]
+				}
 				for _, repoTagPair := range repoTagPairs {
 					if showDigest {
-						fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", repoTagPair[0], repoTagPair[1], repoDigest, trunctedImage, size)
+						fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", repoTagPair[0], repoTagPair[1], repoDigest, id, size)
 					} else {
-						fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", repoTagPair[0], repoTagPair[1], trunctedImage, size)
+						fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", repoTagPair[0], repoTagPair[1], id, size)
 					}
 				}
 				continue

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -192,6 +192,10 @@ var listPodSandboxCommand = cli.Command{
 			Name:  "output, o",
 			Usage: "Output format, One of: json|yaml|table",
 		},
+		cli.BoolFlag{
+			Name:  "no-trunc",
+			Usage: "Show output without truncating the ID",
+		},
 	},
 	Action: func(context *cli.Context) error {
 		var err error
@@ -205,6 +209,7 @@ var listPodSandboxCommand = cli.Command{
 			verbose: context.Bool("verbose"),
 			quiet:   context.Bool("quiet"),
 			output:  context.String("output"),
+			noTrunc: context.Bool("no-trunc"),
 		}
 		opts.labels, err = parseLabelStringSlice(context.StringSlice("label"))
 		if err != nil {
@@ -417,9 +422,12 @@ func ListPodSandboxes(client pb.RuntimeServiceClient, opts listOptions) error {
 		if !opts.verbose {
 			createdAt := time.Unix(0, pod.CreatedAt)
 			ctm := units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
-			truncatedID := strings.TrimPrefix(pod.Id, "")[:truncatedIDLen]
+			id := pod.Id
+			if !opts.noTrunc {
+				id = strings.TrimPrefix(pod.Id, "")[:truncatedIDLen]
+			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\n",
-				truncatedID, ctm, pod.State, pod.Metadata.Name, pod.Metadata.Namespace, pod.Metadata.Attempt)
+				id, ctm, pod.State, pod.Metadata.Name, pod.Metadata.Namespace, pod.Metadata.Attempt)
 			continue
 		}
 


### PR DESCRIPTION
Add `no-trunc` for `crictl images` and `crictl sandboxes`.

For https://github.com/kubernetes-incubator/cri-tools/issues/179.

Signed-off-by: Lantao Liu <lantaol@google.com>