### PR TITLE
 CRI log parser improvements

### DIFF
--- a/pkg/validate/container.go
+++ b/pkg/validate/container.go
@@ -19,6 +19,7 @@ package validate
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -33,7 +34,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 // streamType is the type of the stream.


### PR DESCRIPTION
→ Possible fix for #228 :
- Modified [`parseCRILog`](https://github.com/kubernetes-incubator/cri-tools/blob/bb2c5293bfa6dd5207e1ce3f2d5a32b09f1cc549/pkg/validate/container.go#L431) to use `strings.SplitN` instead of multiple calls to `strings.Fields`.
- Check the resulting array to make sure it has the correct or the expected size and avoid errors when accessing different fields.