### PR TITLE
Add reopen container log test.

### DIFF
--- a/hack/run-critest.sh
+++ b/hack/run-critest.sh
@@ -30,7 +30,8 @@ docker run --rm -v /usr/local/bin:/target jpetazzo/nsenter
 sleep 10
 
 # Run e2e test cases
-critest v
+# Skip reopen container log test because docker doesn't support it.
+critest --skip="runtime should support reopening container log" v
 
 # Run benchmark test cases
 critest b


### PR DESCRIPTION
Add test for `ReopenContainerLog`.

I've tested it with cri-containerd:
```console
[k8s.io] Container runtime should support log 
  runtime should support reopening container log [Conformance]
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:226
[BeforeEach] [k8s.io] Container
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:50
[BeforeEach] [k8s.io] Container
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:63
[BeforeEach] runtime should support log
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:194
STEP: create a PodSandbox with log directory
[It] runtime should support reopening container log [Conformance]
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:226
STEP: create container with log
STEP: create a container with log and name
STEP: Get image status for image: busybox:1.26
STEP: Create container.
Feb 13 01:44:53.692: INFO: Created container "4e12a1578c465c15a409a24cf279ccab38f191e57603a3c80699b15f26a8c7cb"

STEP: start container with log
STEP: Start container for containerID: 4e12a1578c465c15a409a24cf279ccab38f191e57603a3c80699b15f26a8c7cb
Feb 13 01:44:53.828: INFO: Started container "4e12a1578c465c15a409a24cf279ccab38f191e57603a3c80699b15f26a8c7cb"

Feb 13 01:44:53.828: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log
Feb 13 01:44:53.828: INFO: Parse container log succeed
STEP: rename container log
STEP: reopen container log
Feb 13 01:44:53.829: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log
Feb 13 01:44:53.829: INFO: Parse container log succeed
Feb 13 01:44:54.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log
Feb 13 01:44:54.830: INFO: Parse container log succeed
Feb 13 01:44:54.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:54.830: INFO: Parse container log succeed
Feb 13 01:44:54.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:54.830: INFO: Parse container log succeed
Feb 13 01:44:55.830: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:55.830: INFO: Parse container log succeed
Feb 13 01:44:56.831: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:56.831: INFO: Parse container log succeed
Feb 13 01:44:57.831: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:57.831: INFO: Parse container log succeed
Feb 13 01:44:58.832: INFO: Open log file /tmp/podLogTest973226121/PodSandbox-with-log-directory-7c4be0f2-105f-11e8-ac8e-42010af00002/container-reopen-log-test-7ccc3fcf-105f-11e8-ac8e-42010af00002.log.new
Feb 13 01:44:58.832: INFO: Parse container log succeed
[AfterEach] runtime should support log
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:198
STEP: stop PodSandbox
STEP: delete PodSandbox
STEP: clean up the TempDir
[AfterEach] [k8s.io] Container
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:51

• [SLOW TEST:7.404 seconds]
[k8s.io] Container
/home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/framework/framework.go:72
  runtime should support log
  /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:190
    runtime should support reopening container log [Conformance]
    /home/lantaol/workspace/src/github.com/kubernetes-incubator/cri-tools/pkg/validate/container.go:226

```
@feiskyer @yujuhong @mrunalp 
Signed-off-by: Lantao Liu <lantaol@google.com>