### PR TITLE
pkg: validate: validate Username not empty in ImageStatus

### DIFF
--- a/images/image-user/Dockerfile
+++ b/images/image-user/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+ARG USER
+USER ${USER}

--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -1,0 +1,33 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: all test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
+
+all: test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
+
+test-image-user-uid:
+	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=1002
+	gcloud docker -- push gcr.io/cri-tools/$@
+
+test-image-user-username:
+	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=www-data
+	gcloud docker -- push gcr.io/cri-tools/$@
+
+test-image-user-uid-group:
+	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=1003:users
+	gcloud docker -- push gcr.io/cri-tools/$@
+
+test-image-user-username-group:
+	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=www-data:100
+	gcloud docker -- push gcr.io/cri-tools/$@


### PR DESCRIPTION
Kubernetes rely on that Username field to provide RunAsUser, we need to
validate runtimes correctly return it. We had recently an issue in
CRI-O for that.

@feiskyer @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>