### PR TITLE
Improve image test and make test run in parallel.

### DIFF
--- a/hack/run-critest.sh
+++ b/hack/run-critest.sh
@@ -31,7 +31,7 @@ sleep 10
 
 # Run e2e test cases
 # Skip reopen container log test because docker doesn't support it.
-critest --skip="runtime should support reopening container log" v
+critest --skip="runtime should support reopening container log" --ginkgo-flags=--nodes=8 v
 
 # Run benchmark test cases
 critest b

--- a/images/image-test/Dockerfile
+++ b/images/image-test/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+ARG TEST
+RUN touch ${TEST}

--- a/images/image-test/Makefile
+++ b/images/image-test/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: all test-image-list test-image-tags
+
+all: test-image-list test-image-tags
+
+IMAGES_LIST = test-image-1 test-image-2 test-image-3 test-image-latest test-image-digest test-image-tag:test
+test-image-list:
+	$(foreach name,$(IMAGES_LIST),docker build . -t gcr.io/cri-tools/$(name) --build-arg TEST=$(name);)
+	$(foreach name,$(IMAGES_LIST),gcloud docker -- push gcr.io/cri-tools/$(name);)
+
+test-image-tags:
+	docker build . -t gcr.io/cri-tools/$@:1 --build-arg TEST=$@
+	docker tag gcr.io/cri-tools/$@:1 gcr.io/cri-tools/$@:2
+	docker tag gcr.io/cri-tools/$@:1 gcr.io/cri-tools/$@:3
+	gcloud docker -- push gcr.io/cri-tools/$@:1
+	gcloud docker -- push gcr.io/cri-tools/$@:2
+	gcloud docker -- push gcr.io/cri-tools/$@:3

--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -229,7 +229,7 @@ func ListImage(c internalapi.ImageManagerService, filter *runtimeapi.ImageFilter
 }
 
 // PullPublicImage pulls the public image named imageName.
-func PullPublicImage(c internalapi.ImageManagerService, imageName string) {
+func PullPublicImage(c internalapi.ImageManagerService, imageName string) string {
 	if !strings.Contains(imageName, ":") {
 		imageName = imageName + ":latest"
 		Logf("Use latest as default image tag.")
@@ -239,6 +239,7 @@ func PullPublicImage(c internalapi.ImageManagerService, imageName string) {
 	imageSpec := &runtimeapi.ImageSpec{
 		Image: imageName,
 	}
-	_, err := c.PullImage(imageSpec, nil)
+	id, err := c.PullImage(imageSpec, nil)
 	ExpectNoError(err, "failed to pull image: %v", err)
+	return id
 }

--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -18,6 +18,7 @@ package validate
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -245,7 +246,7 @@ func checkPortForward(c internalapi.RuntimeService, portForwardSeverURL string) 
 	framework.ExpectNoError(err, "failed to create spdy round tripper")
 	url := parseURL(c, portForwardSeverURL)
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
-	pf, err := portforward.New(dialer, []string{"8000:80"}, stopChan, readyChan, os.Stdout, os.Stderr)
+	pf, err := portforward.New(dialer, []string{fmt.Sprintf("%d:80", nginxHostPortForPortForward)}, stopChan, readyChan, os.Stdout, os.Stderr)
 	framework.ExpectNoError(err, "failed to create port forward for %q", portForwardSeverURL)
 
 	go func() {
@@ -255,7 +256,7 @@ func checkPortForward(c internalapi.RuntimeService, portForwardSeverURL string) 
 		framework.ExpectNoError(err, "failed to start port forward for %q", portForwardSeverURL)
 	}()
 
-	By("check if we can get nginx main page via localhost:8000")
-	checkNginxMainPage(c, "", true)
+	By(fmt.Sprintf("check if we can get nginx main page via localhost:%d", nginxHostPortForPortForward))
+	checkNginxMainPage(c, "", nginxHostPortForPortForward)
 	framework.Logf("Check port forward url %q succeed", portForwardSeverURL)
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/cri-tools/issues/241.

This PR:
1) Added `images/` directory which contains test images used in CRI validation test. @runcom We can also move your test image to `images/`. I'll push it to `gcr.io/cri-tools` for you.
2) Improve image test to make it be able to run in parallel with other tests.

By running test in parallel, it only takes <20s now.
```
•
Ran 56 of 57 Specs in 18.565 seconds
SUCCESS! -- 56 Passed | 0 Failed | 0 Pending | 1 Skipped 

```
Signed-off-by: Lantao Liu <lantaol@google.com>