### PR TITLE
Change CRI endpoints environment variable

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -130,13 +130,13 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "runtime-endpoint, r",
-			EnvVar: "CRI_RUNTIME_ENDPOINT",
+			EnvVar: "CONTAINER_RUNTIME_ENDPOINT",
 			Value:  "unix:///var/run/dockershim.sock",
 			Usage:  "Endpoint of CRI container runtime service",
 		},
 		cli.StringFlag{
 			Name:   "image-endpoint, i",
-			EnvVar: "CRI_IMAGE_ENDPOINT",
+			EnvVar: "IMAGE_SERVICE_ENDPOINT",
 			Usage:  "Endpoint of CRI image manager service",
 		},
 		cli.DurationFlag{

--- a/cmd/critest/main.go
+++ b/cmd/critest/main.go
@@ -48,13 +48,13 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "runtime-endpoint, r",
-			EnvVar: "CRI_RUNTIME_ENDPOINT",
+			EnvVar: "CONTAINER_RUNTIME_ENDPOINT",
 			Value:  "unix:///var/run/dockershim.sock",
 			Usage:  "CRI runtime service address which is tested.",
 		},
 		cli.StringFlag{
 			Name:   "image-endpoint, i",
-			EnvVar: "CRI_IMAGE_ENDPOINT",
+			EnvVar: "IMAGE_SERVICE_ENDPOINT",
 			Usage:  "CRI image service address which is tested. Same with runtime-address if not specified.",
 		},
 		cli.StringFlag{

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -35,7 +35,7 @@ This will
 critest connects to `unix:///var/run/dockershim.sock` by default. For other runtimes, the endpoint can be set in two ways:
 
 - By setting flags `--runtime-endpoint` and `--image-endpoint`
-- By setting environment variables `CRI_RUNTIME_ENDPOINT` and `CRI_IMAGE_ENDPOINT`
+- By setting environment variables `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`
 
 ## Additional options
 

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -50,7 +50,7 @@ Subcommands includes:
 crictl connects to `unix:///var/run/dockershim.sock` by default. For other runtimes, the endpoint can be set in three ways:
 
 - By setting flags `--runtime-endpoint` and `--image-endpoint`
-- By setting environment variables `CRI_RUNTIME_ENDPOINT` and `CRI_IMAGE_ENDPOINT`
+- By setting environment variables `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`
 - By setting the endpoint in the config file `--config=/etc/crictl.yaml`
 
 ```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -37,7 +37,7 @@ This will
 critest connects to `unix:///var/run/dockershim.sock` by default. For other runtimes, the endpoint can be set in two ways:
 
 - By setting flags `--runtime-endpoint` and `--image-endpoint`
-- By setting environment variables `CRI_RUNTIME_ENDPOINT` and `CRI_IMAGE_ENDPOINT`
+- By setting environment variables `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`
 
 ## Additional options
 


### PR DESCRIPTION
This PR changes CRI endpoints environment variable to `CONTAINER_RUNTIME_ENDPOINT` and `IMAGE_SERVICE_ENDPOINT`.

Fixes #215.


/cc @Random-Liu @mikebrow