### PR TITLE
Allow combining of short boolean options.

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -31,9 +31,10 @@ import (
 )
 
 var runtimeAttachCommand = cli.Command{
-	Name:      "attach",
-	Usage:     "Attach to a running container",
-	ArgsUsage: "CONTAINER",
+	Name:                   "attach",
+	Usage:                  "Attach to a running container",
+	ArgsUsage:              "CONTAINER",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "tty,t",

--- a/cmd/crictl/config.go
+++ b/cmd/crictl/config.go
@@ -60,9 +60,10 @@ func writeConfig(c *Config, filepath string) error {
 }
 
 var configCommand = cli.Command{
-	Name:      "config",
-	Usage:     "Get and set crictl options",
-	ArgsUsage: "[<options>]",
+	Name:                   "config",
+	Usage:                  "Get and set crictl options",
+	ArgsUsage:              "[<options>]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "get",

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -102,9 +102,10 @@ var startContainerCommand = cli.Command{
 }
 
 var updateContainerCommand = cli.Command{
-	Name:      "update",
-	Usage:     "Update one or more running containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	Name:                   "update",
+	Usage:                  "Update one or more running containers",
+	ArgsUsage:              "CONTAINER [CONTAINER...]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name:  "cpu-period",
@@ -165,9 +166,10 @@ var updateContainerCommand = cli.Command{
 }
 
 var stopContainerCommand = cli.Command{
-	Name:      "stop",
-	Usage:     "Stop one or more running containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	Name:                   "stop",
+	Usage:                  "Stop one or more running containers",
+	ArgsUsage:              "CONTAINER [CONTAINER...]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name:  "timeout, t",
@@ -218,9 +220,10 @@ var removeContainerCommand = cli.Command{
 }
 
 var containerStatusCommand = cli.Command{
-	Name:      "inspect",
-	Usage:     "Display the status of one or more containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	Name:                   "inspect",
+	Usage:                  "Display the status of one or more containers",
+	ArgsUsage:              "CONTAINER [CONTAINER...]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "output, o",
@@ -253,6 +256,7 @@ var containerStatusCommand = cli.Command{
 var listContainersCommand = cli.Command{
 	Name:  "ps",
 	Usage: "List containers",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "verbose, v",

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -36,9 +36,10 @@ const (
 )
 
 var runtimeExecCommand = cli.Command{
-	Name:      "exec",
-	Usage:     "Run a command in a running container",
-	ArgsUsage: "CONTAINER COMMAND [ARG...]",
+	Name:                   "exec",
+	Usage:                  "Run a command in a running container",
+	ArgsUsage:              "CONTAINER COMMAND [ARG...]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "sync, s",

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -48,6 +48,7 @@ func (a imageByRef) Less(i, j int) bool {
 var pullImageCommand = cli.Command{
 	Name:  "pull",
 	Usage: "Pull an image from a registry",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "creds",
@@ -85,9 +86,10 @@ var pullImageCommand = cli.Command{
 }
 
 var listImageCommand = cli.Command{
-	Name:      "images",
-	Usage:     "List images",
-	ArgsUsage: "[REPOSITORY[:TAG]]",
+	Name:                   "images",
+	Usage:                  "List images",
+	ArgsUsage:              "[REPOSITORY[:TAG]]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "verbose, v",
@@ -186,9 +188,10 @@ var listImageCommand = cli.Command{
 }
 
 var imageStatusCommand = cli.Command{
-	Name:      "inspecti",
-	Usage:     "Return the status of one ore more images",
-	ArgsUsage: "IMAGEID [IMAGEID...]",
+	Name:                   "inspecti",
+	Usage:                  "Return the status of one ore more images",
+	ArgsUsage:              "IMAGEID [IMAGEID...]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "output, o",

--- a/cmd/crictl/info.go
+++ b/cmd/crictl/info.go
@@ -26,9 +26,10 @@ import (
 )
 
 var runtimeStatusCommand = cli.Command{
-	Name:      "info",
-	Usage:     "Display information of the container runtime",
-	ArgsUsage: "",
+	Name:                   "info",
+	Usage:                  "Display information of the container runtime",
+	ArgsUsage:              "",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "output, o",

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -29,9 +29,10 @@ import (
 )
 
 var logsCommand = cli.Command{
-	Name:      "logs",
-	Usage:     "Fetch the logs of a container",
-	ArgsUsage: "CONTAINER",
+	Name:                   "logs",
+	Usage:                  "Fetch the logs of a container",
+	ArgsUsage:              "CONTAINER",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "follow, f",

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -115,9 +115,10 @@ var removePodSandboxCommand = cli.Command{
 }
 
 var podSandboxStatusCommand = cli.Command{
-	Name:      "inspectp",
-	Usage:     "Display the status of one or more pod sandboxes",
-	ArgsUsage: "PODSANDBOX [PODSANDBOX...]",
+	Name:                   "inspectp",
+	Usage:                  "Display the status of one or more pod sandboxes",
+	ArgsUsage:              "PODSANDBOX [PODSANDBOX...]",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "output, o",
@@ -150,6 +151,7 @@ var podSandboxStatusCommand = cli.Command{
 var listPodSandboxCommand = cli.Command{
 	Name:  "pods",
 	Usage: "List pod sandboxes",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "id",

--- a/cmd/crictl/stats.go
+++ b/cmd/crictl/stats.go
@@ -50,6 +50,7 @@ var statsCommand = cli.Command{
 	Name: "stats",
 	// TODO(random-liu): Support live monitoring of resource usage.
 	Usage: "List container(s) resource usage statistics",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:  "all, a",

--- a/cmd/critest/benchmark.go
+++ b/cmd/critest/benchmark.go
@@ -23,6 +23,7 @@ import (
 var benchmarkCommand = cli.Command{
 	Name:  "benchmark",
 	Usage: "Benchmark test suite for CRI",
+	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "number, n",

--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/onsi/gomega d59fa0ac68bb5dd932ee8d24eed631cdd519efc3
 github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
 github.com/pborman/uuid ca53cad383cad2479bbba7f7a1a05797ec1386e4
 github.com/spf13/pflag 9ff6c6923cfffbcd502984b8e0c80539a94968b7
-github.com/urfave/cli 7fb9c86b14e6a702a4157ccb5a863f07d844a207
+github.com/urfave/cli 8e01ec4cd3e2d84ab2fe90d8210528ffbb06d8ff
 golang.org/x/crypto 81e90905daefcd6fd217b62423c0908922eadb30
 golang.org/x/net 1c05540f6879653db88113bc4a2b70aec4bd491f
 golang.org/x/sys 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce

--- a/vendor/github.com/urfave/cli/README.md
+++ b/vendor/github.com/urfave/cli/README.md
@@ -9,9 +9,9 @@ cli
 [![top level coverage](https://gocover.io/_badge/github.com/urfave/cli?0 "top level coverage")](http://gocover.io/github.com/urfave/cli) /
 [![altsrc coverage](https://gocover.io/_badge/github.com/urfave/cli/altsrc?0 "altsrc coverage")](http://gocover.io/github.com/urfave/cli/altsrc)
 
-**Notice:** This is the library formerly known as
-`github.com/codegangsta/cli` -- Github will automatically redirect requests
-to this repository, but we recommend updating your references for clarity.
+This is the library formerly known as `github.com/codegangsta/cli` -- Github
+will automatically redirect requests to this repository, but we recommend
+updating your references for clarity.
 
 cli is a simple, fast, and fun package for building command line apps in Go. The
 goal is to enable developers to write fast and distributable command line
@@ -32,6 +32,7 @@ applications in an expressive way.
     + [Alternate Names](#alternate-names)
     + [Ordering](#ordering)
     + [Values from the Environment](#values-from-the-environment)
+    + [Values from files](#values-from-files)
     + [Values from alternate input sources (YAML, TOML, and others)](#values-from-alternate-input-sources-yaml-toml-and-others)
     + [Precedence](#precedence)
   * [Subcommands](#subcommands)
@@ -46,6 +47,7 @@ applications in an expressive way.
   * [Version Flag](#version-flag)
     + [Customization](#customization-2)
     + [Full API Example](#full-api-example)
+  * [Combining short Bool options](#combining-short-bool-options)
 - [Contribution Guidelines](#contribution-guidelines)
 
 <!-- tocstop -->
@@ -139,13 +141,17 @@ discovery. So a cli app can be as little as one line of code in `main()`.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
 )
 
 func main() {
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -160,6 +166,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -174,7 +181,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -198,6 +208,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -212,7 +223,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -261,6 +275,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -274,7 +289,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -290,6 +308,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -319,7 +338,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -333,6 +355,7 @@ scanned.
 package main
 
 import (
+  "log"
   "os"
   "fmt"
 
@@ -366,7 +389,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -387,6 +413,7 @@ For example this:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -402,7 +429,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -428,6 +458,7 @@ list for the `Name`. e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -444,7 +475,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -468,6 +502,7 @@ For example this:
 package main
 
 import (
+  "log"
   "os"
   "sort"
 
@@ -511,7 +546,10 @@ func main() {
   sort.Sort(cli.FlagsByName(app.Flags))
   sort.Sort(cli.CommandsByName(app.Commands))
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -534,6 +572,7 @@ You can also have the default value set from the environment via `EnvVar`.  e.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -551,7 +590,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -566,6 +608,7 @@ environment variable that resolves is used as the default.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -583,9 +626,51 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
+
+#### Values from files
+
+You can also have the default value set from file via `FilePath`.  e.g.
+
+<!-- {
+  "args": ["&#45;&#45;help"],
+  "output": "password for the mysql database"
+} -->
+``` go
+package main
+
+import (
+  "log"
+  "os"
+
+  "github.com/urfave/cli"
+)
+
+func main() {
+  app := cli.NewApp()
+
+  app.Flags = []cli.Flag {
+    cli.StringFlag{
+      Name: "password, p",
+      Usage: "password for the mysql database",
+      FilePath: "/etc/mysql/password",
+    },
+  }
+
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+Note that default values set from file (e.g. `FilePath`) take precedence over
+default values set from the enviornment (e.g. `EnvVar`).
 
 #### Values from alternate input sources (YAML, TOML, and others)
 
@@ -616,9 +701,9 @@ the yaml input source for any flags that are defined on that command.  As a note
 the "load" flag used would also have to be defined on the command flags in order
 for this code snipped to work.
 
-Currently only the aboved specified formats are supported but developers can
-add support for other input sources by implementing the
-altsrc.InputSourceContext for their given sources.
+Currently only YAML and JSON files are supported but developers can add support
+for other input sources by implementing the altsrc.InputSourceContext for their
+given sources.
 
 Here is a more complete sample of a command using YAML support:
 
@@ -631,6 +716,7 @@ package notmain
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -653,7 +739,10 @@ func main() {
   app.Before = altsrc.InitInputSourceWithContext(flags, altsrc.NewYamlSourceFromFlagFunc("load"))
   app.Flags = flags
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -679,6 +768,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -731,7 +821,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -747,6 +840,7 @@ E.g.
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -769,7 +863,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -795,6 +892,7 @@ may be set by returning a non-nil error that fulfills `cli.ExitCoder`, *or* a
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -815,7 +913,10 @@ func main() {
     return nil
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -835,6 +936,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -866,7 +968,10 @@ func main() {
     },
   }
 
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -906,6 +1011,7 @@ The default bash completion flag (`--generate-bash-completion`) is defined as
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -924,7 +1030,10 @@ func main() {
       Name: "wat",
     },
   }
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -950,6 +1059,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "io"
   "os"
 
@@ -993,7 +1103,10 @@ VERSION:
     fmt.Println("Ha HA.  I pwnd the help!!1")
   }
 
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1008,6 +1121,7 @@ setting `cli.HelpFlag`, e.g.:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1020,7 +1134,10 @@ func main() {
     EnvVar: "SHOW_HALP,HALPPLZ",
   }
 
-  cli.NewApp().Run(os.Args)
+  err := cli.NewApp().Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1043,6 +1160,7 @@ setting `cli.VersionFlag`, e.g.:
 package main
 
 import (
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1057,7 +1175,10 @@ func main() {
   app := cli.NewApp()
   app.Name = "partay"
   app.Version = "19.99.0"
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1072,6 +1193,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "os"
 
   "github.com/urfave/cli"
@@ -1089,7 +1211,10 @@ func main() {
   app := cli.NewApp()
   app.Name = "partay"
   app.Version = "19.99.0"
-  app.Run(os.Args)
+  err := app.Run(os.Args)
+  if err != nil {
+    log.Fatal(err)
+  }
 }
 ```
 
@@ -1351,7 +1476,7 @@ func main() {
     ec := cli.NewExitError("ohwell", 86)
     fmt.Fprintf(c.App.Writer, "%d", ec.ExitCode())
     fmt.Printf("made it!\n")
-    return ec
+    return nil
   }
 
   if os.Getenv("HEXY") != "" {
@@ -1365,7 +1490,9 @@ func main() {
     "whatever-values": 19.99,
   }
 
-  app.Run(os.Args)
+
+  // ignore error so we don't exit non-zero and break gfmrun README example tests
+  _ = app.Run(os.Args)
 }
 
 func wopAction(c *cli.Context) error {
@@ -1374,18 +1501,26 @@ func wopAction(c *cli.Context) error {
 }
 ```
 
+### Combining short Bool options
+
+Traditional use of boolean options using their shortnames look like this:
+```
+# cmd foobar -s -o
+```
+
+Suppose you want users to be able to combine your bool options with their shortname.  This
+can be done using the **UseShortOptionHandling** bool in your commands.  Suppose your program
+has a two bool flags such as *serve* and *option* with the short options of *-o* and
+*-s* respectively. With **UseShortOptionHandling** set to *true*, a user can use a syntax
+like:
+```
+# cmd foobar -so
+```
+
+If you enable the **UseShortOptionHandling*, then you must not use any flags that have a single
+leading *-* or this will result in failures.  For example, **-option** can no longer be used.  Flags
+with two leading dashes (such as **--options**) are still valid.
+
 ## Contribution Guidelines
 
-Feel free to put up a pull request to fix a bug or maybe add a feature. I will
-give it a code review and make sure that it does not break backwards
-compatibility. If I or any other collaborators agree that it is in line with
-the vision of the project, we will work with you to get the code into
-a mergeable state and merge it into the master branch.
-
-If you have contributed something significant to the project, we will most
-likely add you as a collaborator. As a collaborator you are given the ability
-to merge others pull requests. It is very important that new code does not
-break existing code, so be careful about what code you do choose to merge.
-
-If you feel like you have contributed to the project but have not yet been
-added as a collaborator, we probably forgot to add you, please open an issue.
+See [./CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/vendor/github.com/urfave/cli/app.go
+++ b/vendor/github.com/urfave/cli/app.go
@@ -83,6 +83,9 @@ type App struct {
 	Writer io.Writer
 	// ErrWriter writes error output
 	ErrWriter io.Writer
+	// Execute this function to handle ExitErrors. If not provided, HandleExitCoder is provided to
+	// function as a default, so this is optional.
+	ExitErrHandler ExitErrHandlerFunc
 	// Other custom info
 	Metadata map[string]interface{}
 	// Carries a function which returns app specific info.
@@ -207,7 +210,7 @@ func (a *App) Run(arguments []string) (err error) {
 	if err != nil {
 		if a.OnUsageError != nil {
 			err := a.OnUsageError(context, err, false)
-			HandleExitCoder(err)
+			a.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
@@ -240,8 +243,9 @@ func (a *App) Run(arguments []string) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
+			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
 			ShowAppHelp(context)
-			HandleExitCoder(beforeErr)
+			a.handleExitCoder(context, beforeErr)
 			err = beforeErr
 			return err
 		}
@@ -263,7 +267,7 @@ func (a *App) Run(arguments []string) (err error) {
 	// Run default Action
 	err = HandleAction(a.Action, context)
 
-	HandleExitCoder(err)
+	a.handleExitCoder(context, err)
 	return err
 }
 
@@ -330,7 +334,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if err != nil {
 		if a.OnUsageError != nil {
 			err = a.OnUsageError(context, err, true)
-			HandleExitCoder(err)
+			a.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
@@ -352,7 +356,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 		defer func() {
 			afterErr := a.After(context)
 			if afterErr != nil {
-				HandleExitCoder(err)
+				a.handleExitCoder(context, err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -365,7 +369,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if a.Before != nil {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
-			HandleExitCoder(beforeErr)
+			a.handleExitCoder(context, beforeErr)
 			err = beforeErr
 			return err
 		}
@@ -383,7 +387,7 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	// Run default Action
 	err = HandleAction(a.Action, context)
 
-	HandleExitCoder(err)
+	a.handleExitCoder(context, err)
 	return err
 }
 
@@ -449,7 +453,6 @@ func (a *App) hasFlag(flag Flag) bool {
 }
 
 func (a *App) errWriter() io.Writer {
-
 	// When the app ErrWriter is nil use the package level one.
 	if a.ErrWriter == nil {
 		return ErrWriter
@@ -461,6 +464,14 @@ func (a *App) errWriter() io.Writer {
 func (a *App) appendFlag(flag Flag) {
 	if !a.hasFlag(flag) {
 		a.Flags = append(a.Flags, flag)
+	}
+}
+
+func (a *App) handleExitCoder(context *Context, err error) {
+	if a.ExitErrHandler != nil {
+		a.ExitErrHandler(context, err)
+	} else {
+		HandleExitCoder(err)
 	}
 }
 
@@ -491,7 +502,7 @@ func HandleAction(action interface{}, context *Context) (err error) {
 	} else if a, ok := action.(func(*Context)); ok { // deprecated function signature
 		a(context)
 		return nil
-	} else {
-		return errInvalidActionType
 	}
+
+	return errInvalidActionType
 }

--- a/vendor/github.com/urfave/cli/category.go
+++ b/vendor/github.com/urfave/cli/category.go
@@ -10,7 +10,7 @@ type CommandCategory struct {
 }
 
 func (c CommandCategories) Less(i, j int) bool {
-	return c[i].Name < c[j].Name
+	return lexicographicLess(c[i].Name, c[j].Name)
 }
 
 func (c CommandCategories) Len() int {

--- a/vendor/github.com/urfave/cli/command.go
+++ b/vendor/github.com/urfave/cli/command.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -55,6 +56,10 @@ type Command struct {
 	HideHelp bool
 	// Boolean to hide this command from help or completion
 	Hidden bool
+	// Boolean to enable short-option handling so user can combine several
+	// single-character bool arguements into one
+	// i.e. foobar -o -v -> foobar -ov
+	UseShortOptionHandling bool
 
 	// Full name of command for help, defaults to full command name, including parent commands.
 	HelpName        string
@@ -73,7 +78,7 @@ func (c CommandsByName) Len() int {
 }
 
 func (c CommandsByName) Less(i, j int) bool {
-	return c[i].Name < c[j].Name
+	return lexicographicLess(c[i].Name, c[j].Name)
 }
 
 func (c CommandsByName) Swap(i, j int) {
@@ -106,57 +111,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		)
 	}
 
-	set, err := flagSet(c.Name, c.Flags)
-	if err != nil {
-		return err
-	}
-	set.SetOutput(ioutil.Discard)
-
-	if c.SkipFlagParsing {
-		err = set.Parse(append([]string{"--"}, ctx.Args().Tail()...))
-	} else if !c.SkipArgReorder {
-		firstFlagIndex := -1
-		terminatorIndex := -1
-		for index, arg := range ctx.Args() {
-			if arg == "--" {
-				terminatorIndex = index
-				break
-			} else if arg == "-" {
-				// Do nothing. A dash alone is not really a flag.
-				continue
-			} else if strings.HasPrefix(arg, "-") && firstFlagIndex == -1 {
-				firstFlagIndex = index
-			}
-		}
-
-		if firstFlagIndex > -1 {
-			args := ctx.Args()
-			regularArgs := make([]string, len(args[1:firstFlagIndex]))
-			copy(regularArgs, args[1:firstFlagIndex])
-
-			var flagArgs []string
-			if terminatorIndex > -1 {
-				flagArgs = args[firstFlagIndex:terminatorIndex]
-				regularArgs = append(regularArgs, args[terminatorIndex:]...)
-			} else {
-				flagArgs = args[firstFlagIndex:]
-			}
-
-			err = set.Parse(append(flagArgs, regularArgs...))
-		} else {
-			err = set.Parse(ctx.Args().Tail())
-		}
-	} else {
-		err = set.Parse(ctx.Args().Tail())
-	}
-
-	nerr := normalizeFlags(c.Flags, set)
-	if nerr != nil {
-		fmt.Fprintln(ctx.App.Writer, nerr)
-		fmt.Fprintln(ctx.App.Writer)
-		ShowCommandHelp(ctx, c.Name)
-		return nerr
-	}
+	set, err := c.parseFlags(ctx.Args().Tail())
 
 	context := NewContext(ctx.App, set, ctx)
 	context.Command = c
@@ -167,7 +122,7 @@ func (c Command) Run(ctx *Context) (err error) {
 	if err != nil {
 		if c.OnUsageError != nil {
 			err := c.OnUsageError(context, err, false)
-			HandleExitCoder(err)
+			context.App.handleExitCoder(context, err)
 			return err
 		}
 		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
@@ -184,7 +139,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		defer func() {
 			afterErr := c.After(context)
 			if afterErr != nil {
-				HandleExitCoder(err)
+				context.App.handleExitCoder(context, err)
 				if err != nil {
 					err = NewMultiError(err, afterErr)
 				} else {
@@ -198,7 +153,7 @@ func (c Command) Run(ctx *Context) (err error) {
 		err = c.Before(context)
 		if err != nil {
 			ShowCommandHelp(context, c.Name)
-			HandleExitCoder(err)
+			context.App.handleExitCoder(context, err)
 			return err
 		}
 	}
@@ -210,9 +165,86 @@ func (c Command) Run(ctx *Context) (err error) {
 	err = HandleAction(c.Action, context)
 
 	if err != nil {
-		HandleExitCoder(err)
+		context.App.handleExitCoder(context, err)
 	}
 	return err
+}
+
+func (c *Command) parseFlags(args Args) (*flag.FlagSet, error) {
+	set, err := flagSet(c.Name, c.Flags)
+	if err != nil {
+		return nil, err
+	}
+	set.SetOutput(ioutil.Discard)
+
+	if c.SkipFlagParsing {
+		return set, set.Parse(append([]string{"--"}, args...))
+	}
+
+	if c.UseShortOptionHandling {
+		args = translateShortOptions(args)
+	}
+
+	if !c.SkipArgReorder {
+		args = reorderArgs(args)
+	}
+
+	err = set.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+
+	err = normalizeFlags(c.Flags, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return set, nil
+}
+
+// reorderArgs moves all flags before arguments as this is what flag expects
+func reorderArgs(args []string) []string {
+	var nonflags, flags []string
+
+	readFlagValue := false
+	for i, arg := range args {
+		if arg == "--" {
+			nonflags = append(nonflags, args[i:]...)
+			break
+		}
+
+		if readFlagValue && !strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
+			readFlagValue = false
+			flags = append(flags, arg)
+			continue
+		}
+		readFlagValue = false
+
+		if arg != "-" && strings.HasPrefix(arg, "-") {
+			flags = append(flags, arg)
+
+			readFlagValue = !strings.Contains(arg, "=")
+		} else {
+			nonflags = append(nonflags, arg)
+		}
+	}
+
+	return append(flags, nonflags...)
+}
+
+func translateShortOptions(flagArgs Args) []string {
+	// separate combined flags
+	var flagArgsSeparated []string
+	for _, flagArg := range flagArgs {
+		if strings.HasPrefix(flagArg, "-") && strings.HasPrefix(flagArg, "--") == false && len(flagArg) > 2 {
+			for _, flagChar := range flagArg[1:] {
+				flagArgsSeparated = append(flagArgsSeparated, "-"+string(flagChar))
+			}
+		} else {
+			flagArgsSeparated = append(flagArgsSeparated, flagArg)
+		}
+	}
+	return flagArgsSeparated
 }
 
 // Names returns the names including short names and aliases.

--- a/vendor/github.com/urfave/cli/flag.go
+++ b/vendor/github.com/urfave/cli/flag.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -37,6 +38,18 @@ var HelpFlag Flag = BoolFlag{
 // to display a flag.
 var FlagStringer FlagStringFunc = stringifyFlag
 
+// FlagNamePrefixer converts a full flag name and its placeholder into the help
+// message flag prefix. This is used by the default FlagStringer.
+var FlagNamePrefixer FlagNamePrefixFunc = prefixedNames
+
+// FlagEnvHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagEnvHinter FlagEnvHintFunc = withEnvHint
+
+// FlagFileHinter annotates flag help message with the environment variable
+// details. This is used by the default FlagStringer.
+var FlagFileHinter FlagFileHintFunc = withFileHint
+
 // FlagsByName is a slice of Flag.
 type FlagsByName []Flag
 
@@ -45,7 +58,7 @@ func (f FlagsByName) Len() int {
 }
 
 func (f FlagsByName) Less(i, j int) bool {
-	return f[i].GetName() < f[j].GetName()
+	return lexicographicLess(f[i].GetName(), f[j].GetName())
 }
 
 func (f FlagsByName) Swap(i, j int) {
@@ -112,15 +125,9 @@ func (f GenericFlag) Apply(set *flag.FlagSet) {
 // provided by the user for parsing by the flag
 func (f GenericFlag) ApplyWithError(set *flag.FlagSet) error {
 	val := f.Value
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				if err := val.Set(envVal); err != nil {
-					return fmt.Errorf("could not parse %s as value for flag %s: %s", envVal, f.Name, err)
-				}
-				break
-			}
+	if fileEnvVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if err := val.Set(fileEnvVal); err != nil {
+			return fmt.Errorf("could not parse %s as value for flag %s: %s", fileEnvVal, f.Name, err)
 		}
 	}
 
@@ -163,20 +170,18 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f StringSliceFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				newVal := &StringSlice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
-					}
-				}
-				f.Value = newVal
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &StringSlice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as string value for flag %s: %s", envVal, f.Name, err)
 			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
 		}
 	}
 
@@ -226,20 +231,18 @@ func (f IntSliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f IntSliceFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				newVal := &IntSlice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
-					}
-				}
-				f.Value = newVal
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &IntSlice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as int slice value for flag %s: %s", envVal, f.Name, err)
 			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
 		}
 	}
 
@@ -289,20 +292,18 @@ func (f Int64SliceFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Int64SliceFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				newVal := &Int64Slice{}
-				for _, s := range strings.Split(envVal, ",") {
-					s = strings.TrimSpace(s)
-					if err := newVal.Set(s); err != nil {
-						return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
-					}
-				}
-				f.Value = newVal
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		newVal := &Int64Slice{}
+		for _, s := range strings.Split(envVal, ",") {
+			s = strings.TrimSpace(s)
+			if err := newVal.Set(s); err != nil {
+				return fmt.Errorf("could not parse %s as int64 slice value for flag %s: %s", envVal, f.Name, err)
 			}
+		}
+		if f.Value == nil {
+			f.Value = newVal
+		} else {
+			*f.Value = *newVal
 		}
 	}
 
@@ -324,23 +325,15 @@ func (f BoolFlag) Apply(set *flag.FlagSet) {
 // ApplyWithError populates the flag given the flag set and environment
 func (f BoolFlag) ApplyWithError(set *flag.FlagSet) error {
 	val := false
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				if envVal == "" {
-					val = false
-					break
-				}
-
-				envValBool, err := strconv.ParseBool(envVal)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				val = envValBool
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if envVal == "" {
+			val = false
+		} else {
+			envValBool, err := strconv.ParseBool(envVal)
+			if err != nil {
+				return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
 			}
+			val = envValBool
 		}
 	}
 
@@ -364,23 +357,16 @@ func (f BoolTFlag) Apply(set *flag.FlagSet) {
 // ApplyWithError populates the flag given the flag set and environment
 func (f BoolTFlag) ApplyWithError(set *flag.FlagSet) error {
 	val := true
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				if envVal == "" {
-					val = false
-					break
-				}
 
-				envValBool, err := strconv.ParseBool(envVal)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				val = envValBool
-				break
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		if envVal == "" {
+			val = false
+		} else {
+			envValBool, err := strconv.ParseBool(envVal)
+			if err != nil {
+				return fmt.Errorf("could not parse %s as bool value for flag %s: %s", envVal, f.Name, err)
 			}
+			val = envValBool
 		}
 	}
 
@@ -403,14 +389,8 @@ func (f StringFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f StringFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				f.Value = envVal
-				break
-			}
-		}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		f.Value = envVal
 	}
 
 	eachName(f.Name, func(name string) {
@@ -432,18 +412,12 @@ func (f IntFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f IntFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseInt(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
-				}
-				f.Value = int(envValInt)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseInt(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
 		}
+		f.Value = int(envValInt)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -465,19 +439,13 @@ func (f Int64Flag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Int64Flag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseInt(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = envValInt
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseInt(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as int value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = envValInt
 	}
 
 	eachName(f.Name, func(name string) {
@@ -499,19 +467,13 @@ func (f UintFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f UintFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseUint(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as uint value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = uint(envValInt)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseUint(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as uint value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = uint(envValInt)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -533,19 +495,13 @@ func (f Uint64Flag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Uint64Flag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValInt, err := strconv.ParseUint(envVal, 0, 64)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as uint64 value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = uint64(envValInt)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValInt, err := strconv.ParseUint(envVal, 0, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as uint64 value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = uint64(envValInt)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -567,19 +523,13 @@ func (f DurationFlag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f DurationFlag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValDuration, err := time.ParseDuration(envVal)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as duration for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = envValDuration
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValDuration, err := time.ParseDuration(envVal)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as duration for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = envValDuration
 	}
 
 	eachName(f.Name, func(name string) {
@@ -601,19 +551,13 @@ func (f Float64Flag) Apply(set *flag.FlagSet) {
 
 // ApplyWithError populates the flag given the flag set and environment
 func (f Float64Flag) ApplyWithError(set *flag.FlagSet) error {
-	if f.EnvVar != "" {
-		for _, envVar := range strings.Split(f.EnvVar, ",") {
-			envVar = strings.TrimSpace(envVar)
-			if envVal, ok := syscall.Getenv(envVar); ok {
-				envValFloat, err := strconv.ParseFloat(envVal, 10)
-				if err != nil {
-					return fmt.Errorf("could not parse %s as float64 value for flag %s: %s", envVal, f.Name, err)
-				}
-
-				f.Value = float64(envValFloat)
-				break
-			}
+	if envVal, ok := flagFromFileEnv(f.FilePath, f.EnvVar); ok {
+		envValFloat, err := strconv.ParseFloat(envVal, 10)
+		if err != nil {
+			return fmt.Errorf("could not parse %s as float64 value for flag %s: %s", envVal, f.Name, err)
 		}
+
+		f.Value = float64(envValFloat)
 	}
 
 	eachName(f.Name, func(name string) {
@@ -692,9 +636,17 @@ func withEnvHint(envVar, str string) string {
 			suffix = "%"
 			sep = "%, %"
 		}
-		envText = fmt.Sprintf(" [%s%s%s]", prefix, strings.Join(strings.Split(envVar, ","), sep), suffix)
+		envText = " [" + prefix + strings.Join(strings.Split(envVar, ","), sep) + suffix + "]"
 	}
 	return str + envText
+}
+
+func withFileHint(filePath, str string) string {
+	fileText := ""
+	if filePath != "" {
+		fileText = fmt.Sprintf(" [%s]", filePath)
+	}
+	return str + fileText
 }
 
 func flagValue(f Flag) reflect.Value {
@@ -710,14 +662,29 @@ func stringifyFlag(f Flag) string {
 
 	switch f.(type) {
 	case IntSliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
-			stringifyIntSliceFlag(f.(IntSliceFlag)))
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyIntSliceFlag(f.(IntSliceFlag)),
+			),
+		)
 	case Int64SliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
-			stringifyInt64SliceFlag(f.(Int64SliceFlag)))
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyInt64SliceFlag(f.(Int64SliceFlag)),
+			),
+		)
 	case StringSliceFlag:
-		return withEnvHint(fv.FieldByName("EnvVar").String(),
-			stringifyStringSliceFlag(f.(StringSliceFlag)))
+		return FlagFileHinter(
+			fv.FieldByName("FilePath").String(),
+			FlagEnvHinter(
+				fv.FieldByName("EnvVar").String(),
+				stringifyStringSliceFlag(f.(StringSliceFlag)),
+			),
+		)
 	}
 
 	placeholder, usage := unquoteUsage(fv.FieldByName("Usage").String())
@@ -742,17 +709,22 @@ func stringifyFlag(f Flag) string {
 		placeholder = defaultPlaceholder
 	}
 
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultValueString))
+	usageWithDefault := strings.TrimSpace(usage + defaultValueString)
 
-	return withEnvHint(fv.FieldByName("EnvVar").String(),
-		fmt.Sprintf("%s\t%s", prefixedNames(fv.FieldByName("Name").String(), placeholder), usageWithDefault))
+	return FlagFileHinter(
+		fv.FieldByName("FilePath").String(),
+		FlagEnvHinter(
+			fv.FieldByName("EnvVar").String(),
+			FlagNamePrefixer(fv.FieldByName("Name").String(), placeholder)+"\t"+usageWithDefault,
+		),
+	)
 }
 
 func stringifyIntSliceFlag(f IntSliceFlag) string {
 	defaultVals := []string{}
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+			defaultVals = append(defaultVals, strconv.Itoa(i))
 		}
 	}
 
@@ -763,7 +735,7 @@ func stringifyInt64SliceFlag(f Int64SliceFlag) string {
 	defaultVals := []string{}
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, i := range f.Value.Value() {
-			defaultVals = append(defaultVals, fmt.Sprintf("%d", i))
+			defaultVals = append(defaultVals, strconv.FormatInt(i, 10))
 		}
 	}
 
@@ -775,7 +747,7 @@ func stringifyStringSliceFlag(f StringSliceFlag) string {
 	if f.Value != nil && len(f.Value.Value()) > 0 {
 		for _, s := range f.Value.Value() {
 			if len(s) > 0 {
-				defaultVals = append(defaultVals, fmt.Sprintf("%q", s))
+				defaultVals = append(defaultVals, strconv.Quote(s))
 			}
 		}
 	}
@@ -794,6 +766,21 @@ func stringifySliceFlag(usage, name string, defaultVals []string) string {
 		defaultVal = fmt.Sprintf(" (default: %s)", strings.Join(defaultVals, ", "))
 	}
 
-	usageWithDefault := strings.TrimSpace(fmt.Sprintf("%s%s", usage, defaultVal))
-	return fmt.Sprintf("%s\t%s", prefixedNames(name, placeholder), usageWithDefault)
+	usageWithDefault := strings.TrimSpace(usage + defaultVal)
+	return FlagNamePrefixer(name, placeholder) + "\t" + usageWithDefault
+}
+
+func flagFromFileEnv(filePath, envName string) (val string, ok bool) {
+	for _, envVar := range strings.Split(envName, ",") {
+		envVar = strings.TrimSpace(envVar)
+		if envVal, ok := syscall.Getenv(envVar); ok {
+			return envVal, true
+		}
+	}
+	for _, fileVar := range strings.Split(filePath, ",") {
+		if data, err := ioutil.ReadFile(fileVar); err == nil {
+			return string(data), true
+		}
+	}
+	return "", false
 }

--- a/vendor/github.com/urfave/cli/flag_generated.go
+++ b/vendor/github.com/urfave/cli/flag_generated.go
@@ -13,6 +13,7 @@ type BoolFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Destination *bool
 }
@@ -60,6 +61,7 @@ type BoolTFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Destination *bool
 }
@@ -107,6 +109,7 @@ type DurationFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       time.Duration
 	Destination *time.Duration
@@ -155,6 +158,7 @@ type Float64Flag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       float64
 	Destination *float64
@@ -200,11 +204,12 @@ func lookupFloat64(name string, set *flag.FlagSet) float64 {
 
 // GenericFlag is a flag with type Generic
 type GenericFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  Generic
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Hidden   bool
+	Value    Generic
 }
 
 // String returns a readable representation of this value
@@ -250,6 +255,7 @@ type Int64Flag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       int64
 	Destination *int64
@@ -298,6 +304,7 @@ type IntFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       int
 	Destination *int
@@ -343,11 +350,12 @@ func lookupInt(name string, set *flag.FlagSet) int {
 
 // IntSliceFlag is a flag with type *IntSlice
 type IntSliceFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  *IntSlice
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Hidden   bool
+	Value    *IntSlice
 }
 
 // String returns a readable representation of this value
@@ -390,11 +398,12 @@ func lookupIntSlice(name string, set *flag.FlagSet) []int {
 
 // Int64SliceFlag is a flag with type *Int64Slice
 type Int64SliceFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  *Int64Slice
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Hidden   bool
+	Value    *Int64Slice
 }
 
 // String returns a readable representation of this value
@@ -440,6 +449,7 @@ type StringFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       string
 	Destination *string
@@ -485,11 +495,12 @@ func lookupString(name string, set *flag.FlagSet) string {
 
 // StringSliceFlag is a flag with type *StringSlice
 type StringSliceFlag struct {
-	Name   string
-	Usage  string
-	EnvVar string
-	Hidden bool
-	Value  *StringSlice
+	Name     string
+	Usage    string
+	EnvVar   string
+	FilePath string
+	Hidden   bool
+	Value    *StringSlice
 }
 
 // String returns a readable representation of this value
@@ -535,6 +546,7 @@ type Uint64Flag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       uint64
 	Destination *uint64
@@ -583,6 +595,7 @@ type UintFlag struct {
 	Name        string
 	Usage       string
 	EnvVar      string
+	FilePath    string
 	Hidden      bool
 	Value       uint
 	Destination *uint

--- a/vendor/github.com/urfave/cli/funcs.go
+++ b/vendor/github.com/urfave/cli/funcs.go
@@ -23,6 +23,22 @@ type CommandNotFoundFunc func(*Context, string)
 // is displayed and the execution is interrupted.
 type OnUsageErrorFunc func(context *Context, err error, isSubcommand bool) error
 
+// ExitErrHandlerFunc is executed if provided in order to handle ExitError values
+// returned by Actions and Before/After functions.
+type ExitErrHandlerFunc func(context *Context, err error)
+
 // FlagStringFunc is used by the help generation to display a flag, which is
 // expected to be a single line.
 type FlagStringFunc func(Flag) string
+
+// FlagNamePrefixFunc is used by the default FlagStringFunc to create prefix
+// text for a flag's full name.
+type FlagNamePrefixFunc func(fullName, placeholder string) string
+
+// FlagEnvHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the environment variable details.
+type FlagEnvHintFunc func(envVar, str string) string
+
+// FlagFileHintFunc is used by the default FlagStringFunc to annotate flag help
+// with the file path details.
+type FlagFileHintFunc func(filePath, str string) string

--- a/vendor/github.com/urfave/cli/help.go
+++ b/vendor/github.com/urfave/cli/help.go
@@ -158,8 +158,14 @@ func DefaultAppComplete(c *Context) {
 		if command.Hidden {
 			continue
 		}
-		for _, name := range command.Names() {
-			fmt.Fprintln(c.App.Writer, name)
+		if os.Getenv("_CLI_ZSH_AUTOCOMPLETE_HACK") == "1" {
+			for _, name := range command.Names() {
+				fmt.Fprintf(c.App.Writer, "%s:%s\n", name, command.Usage)
+			}
+		} else {
+			for _, name := range command.Names() {
+				fmt.Fprintf(c.App.Writer, "%s\n", name)
+			}
 		}
 	}
 }

--- a/vendor/github.com/urfave/cli/sort.go
+++ b/vendor/github.com/urfave/cli/sort.go
@@ -1,0 +1,29 @@
+package cli
+
+import "unicode"
+
+// lexicographicLess compares strings alphabetically considering case.
+func lexicographicLess(i, j string) bool {
+	iRunes := []rune(i)
+	jRunes := []rune(j)
+
+	lenShared := len(iRunes)
+	if lenShared > len(jRunes) {
+		lenShared = len(jRunes)
+	}
+
+	for index := 0; index < lenShared; index++ {
+		ir := iRunes[index]
+		jr := jRunes[index]
+
+		if lir, ljr := unicode.ToLower(ir), unicode.ToLower(jr); lir != ljr {
+			return lir < ljr
+		}
+
+		if ir != jr {
+			return ir < jr
+		}
+	}
+
+	return i < j
+}


### PR DESCRIPTION
This change makes for example `crictl ps -aq` possible, fixing

```
# crictl ps -aq
Incorrect Usage: flag provided but not defined: -aq

NAME:
   crictl ps - List containers

USAGE:
   crictl ps [command options] [arguments...]

OPTIONS:
   --all, -a                     Show all containers
   --id value                    Filter by container id
   --label value                 Filter by key=value label
   --last value, -n value        Show last n recently created containers (includes all states) (default: 0)
   --latest, -l                  Show recently created container (includes all states)
   --no-trunc                    Show output without truncating the ID
   --output value, -o value      Output format, One of: json|yaml|table
   --podsandbox value, -p value  Filter by pod sandbox id
   --quiet, -q                   Only display container IDs
   --state value                 Filter by container state
   --verbose, -v                 Show verbose information for containers
   
FATA[0000] flag provided but not defined: -aq           
```

Signed-off-by: Jan Pazdziora <jpazdziora@redhat.com>