### PR TITLE
Enable parallel tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ clean:
 	find . -name \#\* -delete
 
 cross: check-gopath
-	GOOS=windows $(GO) build -o $(CURDIR)/_output/critest.exe \
+	GOOS=windows $(GO) test -c -o $(CURDIR)/_output/critest.exe \
 		$(PROJECT)/cmd/critest
 	GOOS=windows $(GO) build -o $(CURDIR)/_output/crictl.exe \
 		$(PROJECT)/cmd/crictl
@@ -89,6 +89,7 @@ gofmt:
 	./hack/repo-infra/verify/go-tools/verify-gofmt.sh
 
 install.tools:
+	go get -u github.com/onsi/ginkgo/ginkgo
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -14,6 +14,12 @@ sudo tar zxvf critest-v1.0.0-beta.0-linux-amd64.tar.gz -C /usr/local/bin
 rm -f critest-v1.0.0-beta.0-linux-amd64.tar.gz
 ```
 
+critest requires [ginkgo](https://github.com/onsi/ginkgo) to run parallel tests. It could be installed by
+
+```sh
+go get -u github.com/onsi/ginkgo/ginkgo
+```
+
 For v1.0.0-alpha.0 and previous versions, Go and cri-tools source code are also required to run `critest`. The source code could get by running
 
 ```sh
@@ -47,4 +53,5 @@ critest connects to `unix:///var/run/dockershim.sock` by default. For other runt
 - `-image-endpoint`: Set the endpoint of image service. Same with runtime-endpoint if not specified.
 - `-runtime-endpoint`: Set the endpoint of runtime service. Default to `unix:///var/run/dockershim.sock`.
 - `-ginkgo.skip`: Skip the tests that match the regular expression.
+- `-parallel`: The number of parallel test nodes to run (default 1). [ginkgo](https://github.com/onsi/ginkgo) must be installed to run parallel tests.
 - `-h`: Should help and all supported options.

--- a/hack/run-critest.sh
+++ b/hack/run-critest.sh
@@ -31,7 +31,7 @@ sleep 10
 
 # Run e2e test cases
 # Skip reopen container log test because docker doesn't support it.
-critest -ginkgo.skip="runtime should support reopening container log" -ginkgo.parallel.total 8
+critest -ginkgo.skip="runtime should support reopening container log" -parallel 8
 
 # Run benchmark test cases
 critest -benchmark


### PR DESCRIPTION
Addressing https://github.com/kubernetes-incubator/cri-tools/pull/261#issuecomment-373254827.

PR #261 removes the source code dependency from critest, but parallel tests is broken. This PR adds it back by running ginkgo to critest.

Please notice that ginkgo requires the prebuild binary with `.test` ext, so this PR adds a symlink to workaround this.
