### PR TITLE
until there is an auth plan tls testing should support insecure

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -99,7 +99,7 @@ func Attach(client pb.RuntimeServiceClient, opts attachOptions) error {
 		return err
 	}
 	logrus.Debugf("Attach URL: %v", URL)
-	attach, err := remoteclient.NewSPDYExecutor(&restclient.Config{}, "POST", URL)
+	attach, err := remoteclient.NewSPDYExecutor(&restclient.Config{TLSClientConfig: restclient.TLSClientConfig{Insecure: true}}, "POST", URL)
 	if err != nil {
 		return err
 	}

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -141,7 +141,7 @@ func Exec(client pb.RuntimeServiceClient, opts execOptions) error {
 	}
 
 	logrus.Debugf("Exec URL: %v", URL)
-	exec, err := remoteclient.NewSPDYExecutor(&restclient.Config{}, "POST", URL)
+	exec, err := remoteclient.NewSPDYExecutor(&restclient.Config{TLSClientConfig: restclient.TLSClientConfig{Insecure: true}}, "POST", URL)
 	if err != nil {
 		return err
 	}

--- a/pkg/validate/streaming.go
+++ b/pkg/validate/streaming.go
@@ -141,7 +141,7 @@ func checkExec(c internalapi.RuntimeService, execServerURL string) {
 	// Only http is supported now.
 	// TODO: support streaming APIs via tls.
 	url := parseURL(c, execServerURL)
-	e, err := remoteclient.NewSPDYExecutor(&rest.Config{}, "POST", url)
+	e, err := remoteclient.NewSPDYExecutor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}}, "POST", url)
 	framework.ExpectNoError(err, "failed to create executor for %q", execServerURL)
 
 	err = e.Stream(remoteclient.StreamOptions{
@@ -232,7 +232,7 @@ func checkAttach(c internalapi.RuntimeService, attachServerURL string) {
 	// Only http is supported now.
 	// TODO: support streaming APIs via tls.
 	url := parseURL(c, attachServerURL)
-	e, err := remoteclient.NewSPDYExecutor(&rest.Config{}, "POST", url)
+	e, err := remoteclient.NewSPDYExecutor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}}, "POST", url)
 	framework.ExpectNoError(err, "failed to create executor for %q", attachServerURL)
 
 	err = e.Stream(remoteclient.StreamOptions{
@@ -264,7 +264,7 @@ func checkPortForward(c internalapi.RuntimeService, portForwardSeverURL string) 
 	readyChan := make(chan struct{})
 	defer close(stopChan)
 
-	transport, upgrader, err := spdy.RoundTripperFor(&rest.Config{})
+	transport, upgrader, err := spdy.RoundTripperFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: true}})
 	framework.ExpectNoError(err, "failed to create spdy round tripper")
 	url := parseURL(c, portForwardSeverURL)
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)


### PR DESCRIPTION
Over on https://github.com/containerd/cri/pull/681 we added support to containerd/cri and expected that critools would support tls without auth.  However, the following error occurs when attempt to run validation:

Mar 19 20:49:18.310: INFO: Unexpected error occurred: error sending request: Post https://10.20.0.36:10010/attach/Vy2abuwM: x509: certificate signed by unknown authority

This commit relaxes the certificate requirement on the server, before an encrypted stream can be started from crictl and critest validate.  

We should probably discuss, and/or open an issue to discuss, security requirements for streaming for the CRI API.

@Random-Liu 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>