### PR TITLE
Add host network portforward test.

### DIFF
--- a/images/hostnet-nginx/Dockerfile
+++ b/images/hostnet-nginx/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nginx
+ARG PORT
+RUN sed -i "s/listen\s*80;/listen ${PORT};/g" /etc/nginx/conf.d/default.conf

--- a/images/hostnet-nginx/Makefile
+++ b/images/hostnet-nginx/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: all
+
+all: hostnet-nginx
+
+hostnet-nginx:
+	docker build . -t gcr.io/cri-tools/$@ --build-arg PORT=12003
+	gcloud docker -- push gcr.io/cri-tools/$@


### PR DESCRIPTION
We recently found a bug that after getting rid of `nsenter`, containerd doesn't support portforward for hostnetwork pod. https://github.com/containerd/cri/issues/738

This should be tested in CRI validation test. But this test should not be `Conformance`, because it requires host network.

Signed-off-by: Lantao Liu <lantaol@google.com>