### PR TITLE
Use busybox:1.28 instead of busybox:1.26

### DIFF
--- a/pkg/framework/util.go
+++ b/pkg/framework/util.go
@@ -50,7 +50,7 @@ const (
 	DefaultAttempt uint32 = 2
 
 	// DefaultContainerImage is the default image for container using
-	DefaultContainerImage string = "busybox:1.26"
+	DefaultContainerImage string = "busybox:1.28"
 
 	// DefaultStopContainerTimeout is the default timeout for stopping container
 	DefaultStopContainerTimeout int64 = 60


### PR DESCRIPTION
Use multi-arch busybox:1.28 image instead of busybox:1.26

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>