### PR TITLE
Disable glog writing to files.

### DIFF
--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"sort"
@@ -88,6 +89,10 @@ func getRuntimeService(context *cli.Context) (cri.RuntimeService, error) {
 }
 
 func main() {
+	// Do not log to files.
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		logrus.WithError(err).Fatal("Failed to set logtostderr=true")
+	}
 	app := cli.NewApp()
 	app.Name = "crictl"
 	app.Usage = "client for CRI"


### PR DESCRIPTION
Today whenever we run `crictl`, it generates several log files under `/tmp`:
```console
$ ls /tmp/crictl*
/tmp/crictl.INFO                                                 /tmp/crictl.lantaol0.root.log.INFO.20180420-153525.177197    /tmp/crictl.lantaol0.root.log.WARNING.20180417-191720.113028
/tmp/crictl.lantaol0.lantaol.log.INFO.20180420-153505.177099     /tmp/crictl.lantaol0.root.log.INFO.20180420-153525.177205    /tmp/crictl.lantaol0.root.log.WARNING.20180420-153524.177178
/tmp/crictl.lantaol0.lantaol.log.INFO.20180420-162337.191963     /tmp/crictl.lantaol0.root.log.INFO.20180420-153526.177214    /tmp/crictl.lantaol0.root.log.WARNING.20180420-153524.177187
```

This becomes a problem if we run the command in a loop, e.g. we run `crictl` every 10 seconds to check containerd healthness https://github.com/containerd/cri/blob/master/cluster/health-monitor.sh#L43.

This can eventually fill the tmp directly. I do believe no one looks at those log files, and most people just read stderr. 

Actually, `crictl` doesn't even have flags for glogs:
```console
$ crictl --help
NAME:
   crictl - client for CRI

USAGE:
   crictl [global options] command [command options] [arguments...]

VERSION:
   1.0.0-beta.0

COMMANDS:
     attach        Attach to a running container
     create        Create a new container
     exec          Run a command in a running container
     version       Display runtime version information
     images        List images
     inspect       Display the status of one or more containers
     inspecti      Return the status of one ore more images
     inspectp      Display the status of one or more pods
     logs          Fetch the logs of a container
     port-forward  Forward local port to a pod
     ps            List containers
     pull          Pull an image from a registry
     runp          Run a new pod
     rm            Remove one or more containers
     rmi           Remove one or more images
     rmp           Remove one or more pods
     pods          List pods
     start         Start one or more created containers
     info          Display information of the container runtime
     stop          Stop one or more running containers
     stopp         Stop one or more running pods
     update        Update one or more running containers
     config        Get and set crictl options
     stats         List container(s) resource usage statistics
     completion    Output bash shell completion code
     help, h       Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value            Location of the client config file (default: "/etc/crictl.yaml") [$CRI_CONFIG_FILE]
   --debug, -D                         Enable debug mode
   --image-endpoint value, -i value    Endpoint of CRI image manager service [$IMAGE_SERVICE_ENDPOINT]
   --runtime-endpoint value, -r value  Endpoint of CRI container runtime service (default: "unix:///var/run/dockershim.sock") [$CONTAINER_RUNTIME_ENDPOINT]
   --timeout value, -t value           Timeout of connecting to the server (default: 10s)
   --help, -h                          show help
   --version, -v                       print the version
```

Let's just always set `logtostderr=true`.

Signed-off-by: Lantao Liu <lantaol@google.com>