### PR TITLE
Make crictl and critest statically linked.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ ifndef GOPATH
 endif
 
 critest: check-gopath
-		$(GO) test -c \
+		CGO_ENABLED=0 $(GO) test -c \
 		$(PROJECT)/cmd/critest \
 		-o $(GOBINDIR)/bin/critest
 
 crictl: check-gopath
-		$(GO) install \
+		CGO_ENABLED=0 $(GO) install \
 		$(PROJECT)/cmd/crictl
 
 clean:


### PR DESCRIPTION
Make `crictl` and `critest` statically linked.

This makes is possible to use `crictl` inside container. (See https://github.com/kubernetes/kubernetes/issues/63355)
This also makes the binary smaller.

Statically linked binary:
```
$ ls -alh $GOPATH/bin/crictl
-rwxr-x--- 1 lantaol primarygroup 26M May  2 02:11 /usr/local/google/home/lantaol/workspace/bin/crict
```

Dynamically linked binary:
```
$ ls -alh $GOPATH/bin/crictl
-rwxr-x--- 1 lantaol primarygroup 28M May  2 02:12 /usr/local/google/home/lantaol/workspace/bin/crictl
```
Signed-off-by: Lantao Liu <lantaol@google.com>