### PR TITLE
Make image-user test images multi-arch

### DIFF
--- a/hack/make-rules/BASEIMAGES
+++ b/hack/make-rules/BASEIMAGES
@@ -1,0 +1,5 @@
+amd64=amd64
+arm=arm32v6
+arm64=arm64v8
+ppc64le=ppc64le
+s390x=s390x

--- a/hack/make-rules/Makefile.manifest
+++ b/hack/make-rules/Makefile.manifest
@@ -12,7 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG ARCH
-FROM $ARCH/busybox
-ARG USER
-USER ${USER}
+.PHONY: manifest-tool
+
+MANIFEST_TOOL_DIR := $(shell mktemp -d)
+export PATH := $(MANIFEST_TOOL_DIR):$(PATH)
+
+MANIFEST_TOOL_VERSION := v0.7.0
+
+space :=
+space +=
+comma := ,
+prefix_linux = $(addprefix linux/,$(strip $1))
+join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
+
+manifest-tool:
+	curl -sSL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-linux-amd64 > $(MANIFEST_TOOL_DIR)/manifest-tool
+	chmod +x $(MANIFEST_TOOL_DIR)/manifest-tool

--- a/images/image-user/Makefile
+++ b/images/image-user/Makefile
@@ -12,22 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include ../../hack/make-rules/Makefile.manifest
+include ../../hack/make-rules/BASEIMAGES
+
 .PHONY: all test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
+
+REGISTRY = gcr.io/cri-tools
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+TAG = latest
+IMAGES_LIST = test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
 
 all: test-image-user-uid test-image-user-username test-image-user-uid-group test-image-user-username-group
 
 test-image-user-uid:
-	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=1002
-	gcloud docker -- push gcr.io/cri-tools/$@
+	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1002;)
+	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
 test-image-user-username:
-	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=www-data
-	gcloud docker -- push gcr.io/cri-tools/$@
+	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data;)
+	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
+
 
 test-image-user-uid-group:
-	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=1003:users
-	gcloud docker -- push gcr.io/cri-tools/$@
+	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=1003:users ;)
+	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
 
 test-image-user-username-group:
-	docker build . -t gcr.io/cri-tools/$@ --build-arg USER=www-data:100
-	gcloud docker -- push gcr.io/cri-tools/$@
+	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch)) --build-arg USER=www-data:100 ;)
+	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
+
+push-manifest: manifest-tool
+	$(foreach image,$(IMAGES_LIST),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)


### PR DESCRIPTION
Fixes #287 
This fixes Issue 287 partially. Here "docker push" is used instead of
"gcloud docker -- push" as its depreciated now. [Reference](https://github.com/kubernetes/kubernetes/commit/c0b73645637c248091358a37c7e99bfcfc983f71)

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>