### PR TITLE
Fix Go versin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.10.x
+  - "1.10.2"
 
 go_import_path: github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
1.10.2 is required now to build kubernetes master.