### PR TITLE
Add release scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ install.tools:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install
 
+release:
+	hack/release.sh
 
 .PHONY: \
 	help \
@@ -109,4 +111,5 @@ install.tools:
 	uninstall-crictl \
 	lint \
 	gofmt \
-	install.tools
+	install.tools \
+	release

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Version matrix:
 | Kubernetes Version | cri-tools Version | cri-tools branch |
 |--------------------|-------------------|------------------|
 | 1.11.X             | v1.0.0-beta.1     | master           |
-| 1.10.X             | v1.0.0-beta.0     | release-1.0      |
+| 1.10.X             | v1.0.0-beta.0     | release-1.10     |
 | 1.9.X              | v1.0.0-alpha.0    | release-1.9      |
 | 1.8.X              | v0.2              | release-1.8      |
 | 1.7.X              | v0.1              | release-1.7      |

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run critest with default dockershim.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION=$(git describe --abbrev=0 --tag)
+CRI_CTL_PLATFORMS=(
+    linux/amd64
+    linux/386
+    linux/arm
+    linux/arm64
+    linux/ppc64le
+    linux/s390x
+    windows/amd64
+    windows/386
+)
+CRI_TEST_PLATFORMS=(
+    linux/amd64
+    linux/386
+    linux/arm
+    linux/arm64
+)
+
+# Create releases output directory.
+PROJECT="github.com/kubernetes-incubator/cri-tools"
+CRI_TOOLS_ROOT="$GOPATH/src/$PROJECT"
+mkdir -p ${CRI_TOOLS_ROOT}/_output/releases
+
+# Build and package crictl releases.
+for platform in "${CRI_CTL_PLATFORMS[@]}"; do
+    os="${platform%/*}"
+    arch=$(basename "${platform}")
+
+    CRICTL_BIN="crictl"
+    if [ "$os" == "windows" ]; then
+        CRICTL_BIN="crictl.exe"
+    fi
+
+    GOARCH="$arch" GOOS="$os" CGO_ENABLED=0 go build \
+        -o ${CRI_TOOLS_ROOT}/_output/bin/$arch-$os/${CRICTL_BIN} \
+        ${PROJECT}/cmd/crictl
+    tar zcvf ${CRI_TOOLS_ROOT}/_output/releases/crictl-$VERSION-$os-$arch.tar.gz \
+        -C ${CRI_TOOLS_ROOT}/_output/bin/$arch-$os \
+        ${CRICTL_BIN}
+done
+
+# Build and package critest releases.
+for platform in "${CRI_TEST_PLATFORMS[@]}"; do
+    os="${platform%/*}"
+    arch=$(basename "${platform}")
+
+    CRITEST_BIN="critest"
+    if [ "$os" == "windows" ]; then
+        CRITEST_BIN="critest.exe"
+    fi
+
+    GOARCH="$arch" GOOS="$os" CGO_ENABLED=0 go test -c \
+        -o ${CRI_TOOLS_ROOT}/_output/bin/$arch-$os/${CRITEST_BIN} \
+        ${PROJECT}/cmd/critest
+    tar zcvf ${CRI_TOOLS_ROOT}/_output/releases/critest-$VERSION-$os-$arch.tar.gz \
+        -C ${CRI_TOOLS_ROOT}/_output/bin/$arch-$os \
+        ${CRITEST_BIN}
+done
+


### PR DESCRIPTION
This PR adds a release script to build tar.gz for various platforms.

```sh
$ make release
$ ls _output/releases
crictl-v1.0.0-beta.0-linux-386.tar.gz      critest-v1.0.0-beta.0-linux-386.tar.gz
crictl-v1.0.0-beta.0-linux-amd64.tar.gz    critest-v1.0.0-beta.0-linux-amd64.tar.gz
crictl-v1.0.0-beta.0-linux-arm64.tar.gz    critest-v1.0.0-beta.0-linux-arm64.tar.gz
crictl-v1.0.0-beta.0-linux-arm.tar.gz      critest-v1.0.0-beta.0-linux-arm.tar.gz
crictl-v1.0.0-beta.0-windows-386.tar.gz    critest-v1.0.0-beta.0-windows-386.tar.gz
crictl-v1.0.0-beta.0-windows-amd64.tar.gz  critest-v1.0.0-beta.0-windows-amd64.tar.gz
```

closes #309 