### PR TITLE
Fixes a typo in inspecti usage

### DIFF
--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -194,7 +194,7 @@ var listImageCommand = cli.Command{
 
 var imageStatusCommand = cli.Command{
 	Name:                   "inspecti",
-	Usage:                  "Return the status of one ore more images",
+	Usage:                  "Return the status of one or more images",
 	ArgsUsage:              "IMAGEID [IMAGEID...]",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,


### PR DESCRIPTION
Found a typo while writing out a feature for kubeadm using crictl and wanted to fix it!

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>