### PR TITLE
Make hostnet-nginx test images multi-arch

### DIFF
--- a/images/hostnet-nginx/Dockerfile
+++ b/images/hostnet-nginx/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nginx
-ARG PORT
-RUN sed -i "s/listen\s*80;/listen ${PORT};/g" /etc/nginx/conf.d/default.conf
+ARG ARCH
+FROM $ARCH/nginx
+COPY default.conf /etc/nginx/conf.d/default.conf

--- a/images/hostnet-nginx/Makefile
+++ b/images/hostnet-nginx/Makefile
@@ -12,10 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all
+include ../../hack/make-rules/Makefile.manifest
+include ../../hack/make-rules/BASEIMAGES
 
-all: hostnet-nginx
+.PHONY: all push-manifest
+
+REGISTRY = gcr.io/cri-tools
+ALL_ARCH = amd64 arm64 ppc64le s390x
+TAG = latest
+IMAGES_LIST = hostnet-nginx
+PORT=12003
+
+all: hostnet-nginx push-manifest
 
 hostnet-nginx:
-	docker build . -t gcr.io/cri-tools/$@ --build-arg PORT=12003
-	gcloud docker -- push gcr.io/cri-tools/$@
+	sed -i "s/listen\s*80;/listen ${PORT};/g" default.conf
+	$(foreach arch,$(ALL_ARCH),docker build . -t $(REGISTRY)/$@-$(arch) --build-arg ARCH=$($(arch));)
+	$(foreach arch,$(ALL_ARCH),docker push $(REGISTRY)/$@-$(arch);)
+
+push-manifest: manifest-tool
+	$(foreach image,$(IMAGES_LIST),manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(REGISTRY)/$(image)-ARCH:$(TAG) --target $(REGISTRY)/$(image):$(TAG);)

--- a/images/hostnet-nginx/default.conf
+++ b/images/hostnet-nginx/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
The "RUN sed" command in the Dockerfile makes the building of Docker images for various archs error out with "standard_init_linux.go:190: exec user process caused "exec format error"". Hence I have got out the common /etc/nginx/conf.d/default.conf file and copied it into the image after a sed via Makefile. 
Fixes #287 

Signed-off-by: Nitesh Konkar <niteshkonkar@in.ibm.com>