### PR TITLE
adds id text to each command

### DIFF
--- a/cmd/crictl/attach.go
+++ b/cmd/crictl/attach.go
@@ -33,7 +33,7 @@ import (
 var runtimeAttachCommand = cli.Command{
 	Name:                   "attach",
 	Usage:                  "Attach to a running container",
-	ArgsUsage:              "CONTAINER",
+	ArgsUsage:              "CONTAINER-ID",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{

--- a/cmd/crictl/container.go
+++ b/cmd/crictl/container.go
@@ -82,7 +82,7 @@ var createContainerCommand = cli.Command{
 var startContainerCommand = cli.Command{
 	Name:      "start",
 	Usage:     "Start one or more created containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	ArgsUsage: "CONTAINER-ID [CONTAINER-ID...]",
 	Action: func(context *cli.Context) error {
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
@@ -105,7 +105,7 @@ var startContainerCommand = cli.Command{
 var updateContainerCommand = cli.Command{
 	Name:      "update",
 	Usage:     "Update one or more running containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	ArgsUsage: "CONTAINER-ID [CONTAINER-ID...]",
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name:  "cpu-period",
@@ -163,7 +163,7 @@ var updateContainerCommand = cli.Command{
 var stopContainerCommand = cli.Command{
 	Name:                   "stop",
 	Usage:                  "Stop one or more running containers",
-	ArgsUsage:              "CONTAINER [CONTAINER...]",
+	ArgsUsage:              "CONTAINER-ID [CONTAINER-ID...]",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
@@ -195,7 +195,7 @@ var stopContainerCommand = cli.Command{
 var removeContainerCommand = cli.Command{
 	Name:      "rm",
 	Usage:     "Remove one or more containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	ArgsUsage: "CONTAINER-ID [CONTAINER-ID...]",
 	Action: func(context *cli.Context) error {
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
@@ -218,7 +218,7 @@ var removeContainerCommand = cli.Command{
 var containerStatusCommand = cli.Command{
 	Name:      "inspect",
 	Usage:     "Display the status of one or more containers",
-	ArgsUsage: "CONTAINER [CONTAINER...]",
+	ArgsUsage: "CONTAINER-ID [CONTAINER-ID...]",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "output, o",

--- a/cmd/crictl/exec.go
+++ b/cmd/crictl/exec.go
@@ -38,7 +38,7 @@ const (
 var runtimeExecCommand = cli.Command{
 	Name:                   "exec",
 	Usage:                  "Run a command in a running container",
-	ArgsUsage:              "CONTAINER COMMAND [ARG...]",
+	ArgsUsage:              "CONTAINER-ID COMMAND [ARG...]",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{

--- a/cmd/crictl/image.go
+++ b/cmd/crictl/image.go
@@ -195,7 +195,7 @@ var listImageCommand = cli.Command{
 var imageStatusCommand = cli.Command{
 	Name:                   "inspecti",
 	Usage:                  "Return the status of one or more images",
-	ArgsUsage:              "IMAGEID [IMAGEID...]",
+	ArgsUsage:              "IMAGE-ID [IMAGE-ID...]",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{
@@ -269,7 +269,7 @@ var imageStatusCommand = cli.Command{
 var removeImageCommand = cli.Command{
 	Name:      "rmi",
 	Usage:     "Remove one or more images",
-	ArgsUsage: "IMAGEID [IMAGEID...]",
+	ArgsUsage: "IMAGE-ID [IMAGE-ID...]",
 	Action: func(context *cli.Context) error {
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)

--- a/cmd/crictl/logs.go
+++ b/cmd/crictl/logs.go
@@ -31,7 +31,7 @@ import (
 var logsCommand = cli.Command{
 	Name:                   "logs",
 	Usage:                  "Fetch the logs of a container",
-	ArgsUsage:              "CONTAINER",
+	ArgsUsage:              "CONTAINER-ID",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{

--- a/cmd/crictl/portforward.go
+++ b/cmd/crictl/portforward.go
@@ -36,7 +36,7 @@ import (
 var runtimePortForwardCommand = cli.Command{
 	Name:      "port-forward",
 	Usage:     "Forward local port to a pod",
-	ArgsUsage: "POD [LOCAL_PORT:]REMOTE_PORT",
+	ArgsUsage: "POD-ID [LOCAL_PORT:]REMOTE_PORT",
 	Action: func(context *cli.Context) error {
 		args := context.Args()
 		if len(args) < 2 {

--- a/cmd/crictl/sandbox.go
+++ b/cmd/crictl/sandbox.go
@@ -73,7 +73,7 @@ var runPodCommand = cli.Command{
 var stopPodCommand = cli.Command{
 	Name:      "stopp",
 	Usage:     "Stop one or more running pods",
-	ArgsUsage: "POD [POD...]",
+	ArgsUsage: "POD-ID [POD-ID...]",
 	Action: func(context *cli.Context) error {
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
@@ -95,7 +95,7 @@ var stopPodCommand = cli.Command{
 var removePodCommand = cli.Command{
 	Name:      "rmp",
 	Usage:     "Remove one or more pods",
-	ArgsUsage: "POD [POD...]",
+	ArgsUsage: "POD-ID [POD-ID...]",
 	Action: func(context *cli.Context) error {
 		if context.NArg() == 0 {
 			return cli.ShowSubcommandHelp(context)
@@ -117,7 +117,7 @@ var removePodCommand = cli.Command{
 var podStatusCommand = cli.Command{
 	Name:                   "inspectp",
 	Usage:                  "Display the status of one or more pods",
-	ArgsUsage:              "POD [POD...]",
+	ArgsUsage:              "POD-ID [POD-ID...]",
 	SkipArgReorder:         true,
 	UseShortOptionHandling: true,
 	Flags: []cli.Flag{


### PR DESCRIPTION
While using crictl @estesp reported a nit with the UI.. particularly that it would be nice if we told users POD-ID was needed. As is it says POD, which is confusing. 

I checked and we're just not consistent across the UI so here's a PR to fix that.

@Random-Liu 

address issue #334 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>