### PR TITLE
Set version based on git tags.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ PATH := $(GOBINDIR)/bin:$(PATH)
 GOPKGDIR := $(GOPATH)/src/$(PROJECT)
 GOPKGBASEDIR := $(shell dirname "$(GOPKGDIR)")
 
+VERSION := $(shell git describe --tags --dirty --always)
+VERSION := $(VERSION:v%=%)
+GO_LDFLAGS := -X $(PROJECT)/pkg/version.Version=$(VERSION)
 
 all: binaries
 
@@ -45,11 +48,13 @@ endif
 
 critest: check-gopath
 		CGO_ENABLED=0 $(GO) test -c \
+		-ldflags '$(GO_LDFLAGS)' \
 		$(PROJECT)/cmd/critest \
 		-o $(GOBINDIR)/bin/critest
 
 crictl: check-gopath
 		CGO_ENABLED=0 $(GO) install \
+		-ldflags '$(GO_LDFLAGS)' \
 		$(PROJECT)/cmd/crictl
 
 clean:
@@ -58,8 +63,10 @@ clean:
 
 cross: check-gopath
 	GOOS=windows $(GO) test -c -o $(CURDIR)/_output/critest.exe \
+		-ldflags '$(GO_LDFLAGS)' \
 		$(PROJECT)/cmd/critest
 	GOOS=windows $(GO) build -o $(CURDIR)/_output/crictl.exe \
+		-ldflags '$(GO_LDFLAGS)' \
 		$(PROJECT)/cmd/crictl
 
 binaries: critest crictl

--- a/cmd/crictl/main.go
+++ b/cmd/crictl/main.go
@@ -29,12 +29,13 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	"k8s.io/kubernetes/pkg/kubelet/remote"
 	"k8s.io/kubernetes/pkg/kubelet/util"
+
+	"github.com/kubernetes-incubator/cri-tools/pkg/version"
 )
 
 const (
 	defaultConfigPath = "/etc/crictl.yaml"
 	defaultTimeout    = 10 * time.Second
-	crictlVersion     = "1.11.0"
 )
 
 var (
@@ -97,7 +98,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "crictl"
 	app.Usage = "client for CRI"
-	app.Version = crictlVersion
+	app.Version = version.Version
 
 	app.Commands = []cli.Command{
 		runtimeAttachCommand,

--- a/cmd/critest/cri_test.go
+++ b/cmd/critest/cri_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/kubernetes-incubator/cri-tools/pkg/framework"
+	versionconst "github.com/kubernetes-incubator/cri-tools/pkg/version"
 
 	_ "github.com/kubernetes-incubator/cri-tools/pkg/benchmark"
 	_ "github.com/kubernetes-incubator/cri-tools/pkg/validate"
@@ -41,8 +42,6 @@ const (
 	parallelFlag  = "parallel"
 	benchmarkFlag = "benchmark"
 	versionFlag   = "version"
-
-	criTestVersion = "1.11.0"
 )
 
 var (
@@ -125,7 +124,7 @@ func runParallelTestSuite(t *testing.T) {
 
 func TestCRISuite(t *testing.T) {
 	if *version {
-		fmt.Printf("critest version: %s\n", criTestVersion)
+		fmt.Printf("critest version: %s\n", versionconst.Version)
 		return
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Version holds the complete version number. Filled in at linking time.
+var Version = "unknown"


### PR DESCRIPTION
I want to release a 1.11.1 from `release/1.11`. However, I don't know whether I should only update the version number in `release/1.11` or update both `release/1.11` and master.

If we only update `release/1.11`, master will still stay at `1.11.0`.
But if we update both, master isn't actually at `1.11.1`.

This PR changes to use `git tags` instead, which contains commit number for non-tag commits.

@yujuhong @feiskyer 
Signed-off-by: Lantao Liu <lantaol@google.com>