### PR TITLE
Add cross build in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ jobs:
       script:
         - make lint
         - make gofmt
+    - stage: Build
+      script:
+        - make release
     - stage: Test
       script: 
         - make


### PR DESCRIPTION
Add cross build in travis to avoid issues like https://github.com/kubernetes-incubator/cri-tools/pull/345.

Signed-off-by: Lantao Liu <lantaol@google.com>