### PR TITLE
Add support to install kubelet from the corresponding branch.

### DIFF
--- a/hack/install-kubelet.sh
+++ b/hack/install-kubelet.sh
@@ -21,6 +21,10 @@ set -o pipefail
 # Install kubelet
 ! go get -d k8s.io/kubernetes
 cd $GOPATH/src/k8s.io/kubernetes
+if [ ${TRAVIS_BRANCH:-"master"} != "master" ]; then
+  # We can do this because cri-tools have the same branch name with kubernetes.
+  git checkout "${TRAVIS_BRANCH}"
+fi
 make WHAT='cmd/kubelet'
 sudo cp _output/bin/kubelet /usr/local/bin
 


### PR DESCRIPTION
Add support to install kubelet from a specific release.

So that in release branches, we can set the kubelet version in travis in the future.

Signed-off-by: Lantao Liu <lantaol@google.com>